### PR TITLE
feat: chat 도메인 테이블 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 
 ### Database ###
 *.db
+
+### MacOS ###
+.DS_Store

--- a/src/main/java/org/glue/glue_be/chat/controller/ChatRoomController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/ChatRoomController.java
@@ -1,0 +1,4 @@
+package org.glue.glue_be.chat.controller;
+
+public class ChatRoomController {
+}

--- a/src/main/java/org/glue/glue_be/chat/dto/ChatRoomDto.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/ChatRoomDto.java
@@ -1,0 +1,4 @@
+package org.glue.glue_be.chat.dto;
+
+public class ChatRoomDto {
+}

--- a/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
@@ -18,11 +18,9 @@ public class ChatRoom {
 	@Column(name = "chatroom_id")
 	private Long id;
 
-
-	// chatroom은 meeting과 일대일 매핑관계이다. 단방향으로 가정.
-	// chatroom이 비즈니스적으로 meeting에 속할 때 FK는 전자가 가져야 한다고 한다
-	// cascade는 meeting과의 관계에 대해 명확히 알게되면 추가해야할듯
-	@OneToOne(fetch = FetchType.LAZY)
+	// chatroom이 비즈니스적으로 meeting에 속하기 때문에 여기가 FK를 가짐
+	// cascade는 meeting과의 관계에 대해 명확히 알게되면 추가해야 할 듯
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "meeting_id", unique = true, nullable = false)
 	private Meeting meeting;
 

--- a/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.glue.glue_be.meeting.entity.Meeting;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Entity
 @Getter
@@ -21,6 +24,10 @@ public class ChatRoom {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "meeting_id", nullable = false)
 	private Meeting meeting;
+
+	// ChatRoom과 UserChatroom 간의 일대다 관계 매핑
+	@OneToMany(mappedBy = "chatRoom")
+	private List<UserChatroom> userChatrooms = new ArrayList<>();
 
 	// 생성자를 따로 만들고 Builder를 붙임 -> Allargs 배제
 	@Builder

--- a/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
@@ -28,5 +28,4 @@ public class ChatRoom {
 		this.meeting = meeting;
 	}
 
-
 }

--- a/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
@@ -1,0 +1,29 @@
+package org.glue.glue_be.chat.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.glue.glue_be.meeting.entity.Meeting;
+
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "chatroom")
+public class ChatRoom {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "chatroom_id")
+	private Long id;
+
+
+	// chatroom은 meeting과 일대일 매핑관계이다. 단방향으로 가정.
+	// chatroom이 비즈니스적으로 meeting에 속할 때 FK는 전자가 가져야 한다고 한다
+	// cascade는 meeting과의 관계에 대해 명확히 알게되면 추가해야할듯
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "meeting_id", unique = true, nullable = false)
+	private Meeting meeting;
+
+}

--- a/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
@@ -7,8 +7,6 @@ import org.glue.glue_be.meeting.entity.Meeting;
 
 @Entity
 @Getter
-@Builder(toBuilder = true)
-@AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "chatroom")
 public class ChatRoom {
@@ -21,7 +19,14 @@ public class ChatRoom {
 	// chatroom이 비즈니스적으로 meeting에 속하기 때문에 여기가 FK를 가짐
 	// cascade는 meeting과의 관계에 대해 명확히 알게되면 추가해야 할 듯
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "meeting_id", unique = true, nullable = false)
+	@JoinColumn(name = "meeting_id", nullable = false)
 	private Meeting meeting;
+
+	// 생성자를 따로 만들고 Builder를 붙임 -> Allargs 배제
+	@Builder
+	public ChatRoom(Meeting meeting){
+		this.meeting = meeting;
+	}
+
 
 }

--- a/src/main/java/org/glue/glue_be/chat/entity/Message.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/Message.java
@@ -1,0 +1,28 @@
+package org.glue.glue_be.chat.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "message")
+public class Message {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "message_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "chatroom_id", nullable = false)
+	private ChatRoom chatRoom;
+
+	@Column(name = "message_content", columnDefinition = "TEXT", nullable = false)
+	private String messageContent;
+
+}

--- a/src/main/java/org/glue/glue_be/chat/entity/Message.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/Message.java
@@ -18,6 +18,8 @@ public class Message {
 	@Column(name = "message_id")
 	private Long id;
 
+	// Message와 User는 매개 테이블 없이 직접적인 연관관계를 매핑
+	// 따라서 반대측인 User에서 OneToMany를 작성할 필요 없음
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "chatroom_id", nullable = false)
 	private ChatRoom chatRoom;

--- a/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
@@ -16,6 +16,7 @@ import org.glue.glue_be.user.entity.User;
 @NoArgsConstructor
 @Table(name = "user_chatroom")
 public class UserChatroom {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "user_chatroom_id")
@@ -28,7 +29,5 @@ public class UserChatroom {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "chatRoom_id", nullable = false)
 	private ChatRoom chatRoom;
-
-
 
 }

--- a/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
@@ -1,0 +1,34 @@
+package org.glue.glue_be.chat.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.glue.glue_be.user.entity.User;
+
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "user_chatroom")
+public class UserChatroom {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_chatroom_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "chatRoom_id", nullable = false)
+	private ChatRoom chatRoom;
+
+
+
+}

--- a/src/main/java/org/glue/glue_be/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,4 @@
+package org.glue.glue_be.chat.repository;
+
+public class ChatRoomRepository {
+}

--- a/src/main/java/org/glue/glue_be/chat/service/ChatRoomService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/ChatRoomService.java
@@ -1,0 +1,4 @@
+package org.glue.glue_be.chat.service;
+
+public class ChatRoomService {
+}

--- a/src/main/java/org/glue/glue_be/chatRoom/controller/ChatRoomController.java
+++ b/src/main/java/org/glue/glue_be/chatRoom/controller/ChatRoomController.java
@@ -1,4 +1,0 @@
-package org.glue.glue_be.chatRoom.controller;
-
-public class ChatRoomController {
-}

--- a/src/main/java/org/glue/glue_be/chatRoom/dto/ChatRoomDto.java
+++ b/src/main/java/org/glue/glue_be/chatRoom/dto/ChatRoomDto.java
@@ -1,4 +1,0 @@
-package org.glue.glue_be.chatRoom.dto;
-
-public class ChatRoomDto {
-}

--- a/src/main/java/org/glue/glue_be/chatRoom/entity/ChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chatRoom/entity/ChatRoom.java
@@ -1,4 +1,0 @@
-package org.glue.glue_be.chatRoom.entity;
-
-public class ChatRoom {
-}

--- a/src/main/java/org/glue/glue_be/chatRoom/repository/ChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chatRoom/repository/ChatRoomRepository.java
@@ -1,4 +1,0 @@
-package org.glue.glue_be.chatRoom.repository;
-
-public class ChatRoomRepository {
-}

--- a/src/main/java/org/glue/glue_be/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/org/glue/glue_be/chatRoom/service/ChatRoomService.java
@@ -1,4 +1,0 @@
-package org.glue.glue_be.chatRoom.service;
-
-public class ChatRoomService {
-}


### PR DESCRIPTION
## 변경사항
- Chat 도메인 관련 테이블인 채팅방, 메시지, 유저-채팅방 매개 테이블 변경
- Chatroom->Chat으로 도메인명을 변경
- MacOS 파일인 DS_Store 문서를 gitignore에 추가

close #9 