### PR TITLE
feat: post, like, postImage entity 추가

### DIFF
--- a/src/main/java/org/glue/glue_be/user/entity/Like.java
+++ b/src/main/java/org/glue/glue_be/user/entity/Like.java
@@ -22,10 +22,16 @@ public class Like {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @Builder
+    private Like(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+
     public static Like createLike(User user, Post post) {
-        Like like = new Like();
-        like.user = user;
-        like.post = post;
-        return like;
+        return Like.builder()
+                .user(user)
+                .post(post)
+                .build();
     }
 }

--- a/src/main/java/org/glue/glue_be/user/entity/Like.java
+++ b/src/main/java/org/glue/glue_be/user/entity/Like.java
@@ -1,0 +1,31 @@
+package org.glue.glue_be.user.entity;
+
+import lombok.*;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "like")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Like {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @Column(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    public static Like createLike(User user, Post post) {
+        Like like = new Like();
+        like.user = user;
+        like.post = post;
+        return like;
+    }
+}

--- a/src/main/java/org/glue/glue_be/user/entity/Post.java
+++ b/src/main/java/org/glue/glue_be/user/entity/Post.java
@@ -1,0 +1,82 @@
+package org.glue.glue_be.user.entity;
+
+import lombok.*;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @Column(name = "meeting_id", nullable = false)
+    private Meeting meeting;
+
+    @Column(name = "post_title", nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount;
+
+    @Column(name = "bumped_at", nullable = false)
+    private LocalDateTime bumpedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "post")
+    private List<PostImage> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post")
+    private List<Like> likes = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+        if (this.viewCount == null) {
+            this.viewCount = 0;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public static Post createPost(Meeting meeting, String title, String content) {
+        Post post = new Post();
+        post.meeting = meeting;
+        post.title = title;
+        post.content = content;
+        post.viewCount = 0;
+        post.createdAt = LocalDateTime.now();
+        post.updatedAt = LocalDateTime.now();
+        return post;
+    }
+
+    public void updatePost(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+}

--- a/src/main/java/org/glue/glue_be/user/entity/Post.java
+++ b/src/main/java/org/glue/glue_be/user/entity/Post.java
@@ -45,6 +45,16 @@ public class Post {
     @OneToMany(mappedBy = "post")
     private List<Like> likes = new ArrayList<>();
 
+    @Builder
+    private Post(Meeting meeting, String title, String content, LocalDateTime bumpedAt) {
+        this.meeting = meeting;
+        this.title = title;
+        this.content = content;
+        this.viewCount = 0;
+        this.bumpedAt = bumpedAt != null ? bumpedAt : LocalDateTime.now();
+    }
+
+    // TODO: 컨벤션 확정짓기 (확정 후 주석 제거 예정)
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
@@ -54,20 +64,18 @@ public class Post {
         }
     }
 
+    // TODO: 컨벤션 확정짓기 (확정 후 주석 제거 예정)
     @PreUpdate
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
 
     public static Post createPost(Meeting meeting, String title, String content) {
-        Post post = new Post();
-        post.meeting = meeting;
-        post.title = title;
-        post.content = content;
-        post.viewCount = 0;
-        post.createdAt = LocalDateTime.now();
-        post.updatedAt = LocalDateTime.now();
-        return post;
+        return Post.builder()
+                .meeting(meeting)
+                .title(title)
+                .content(content)
+                .build();
     }
 
     public void updatePost(String title, String content) {
@@ -78,5 +86,9 @@ public class Post {
 
     public void increaseViewCount() {
         this.viewCount++;
+    }
+
+    public void bump() {
+        this.bumpedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/org/glue/glue_be/user/entity/PostImage.java
+++ b/src/main/java/org/glue/glue_be/user/entity/PostImage.java
@@ -7,7 +7,6 @@ import jakarta.persistence.*;
 @Entity
 @Table(name = "post_image")
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostImage {
     @Id
@@ -17,7 +16,7 @@ public class PostImage {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
-    private Post postId;
+    private Post post;
 
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
@@ -25,4 +24,26 @@ public class PostImage {
     @Column(name = "image_order", nullable = false)
     private Integer imageOrder;
 
+    @Builder
+    private PostImage(Post post, String imageUrl, Integer imageOrder) {
+        this.post = post;
+        this.imageUrl = imageUrl;
+        this.imageOrder = imageOrder;
+    }
+
+    public static PostImage createPostImage(Post post, String imageUrl, Integer imageOrder) {
+        return PostImage.builder()
+                .post(post)
+                .imageUrl(imageUrl)
+                .imageOrder(imageOrder)
+                .build();
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateImageOrder(Integer imageOrder) {
+        this.imageOrder = imageOrder;
+    }
 }

--- a/src/main/java/org/glue/glue_be/user/entity/PostImage.java
+++ b/src/main/java/org/glue/glue_be/user/entity/PostImage.java
@@ -1,0 +1,28 @@
+package org.glue.glue_be.user.entity;
+
+import lombok.*;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "post_image")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post postId;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "image_order", nullable = false)
+    private Integer imageOrder;
+
+}


### PR DESCRIPTION
- post, like, postImage entity 추가
- user, meeting 있다고 가정하고, 에러 뜨지만 무시하고 푸시했습니다.
- postImage는 단순히 추가, 삭제밖에 없을 것 같아서 `@setter` 사용했습니다.
- Lombok 어차피 사용하므로 `@NoArgsConstructor(access = AccessLevel.PROTECTED)`를 사용하여 기본 생성자를 대체했습니다.