### PR TITLE
Meeting, Participant 엔터티 클래스 작성

### DIFF
--- a/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
@@ -1,10 +1,14 @@
 package org.glue.glue_be.meeting.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Entity
@@ -16,21 +20,16 @@ public class Meeting {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "meeting_id", nullable = false, updatable = false)
-    private Long id;
+    private Long meetingId;
 
     @Column(name = "meeting_title", nullable = false)
-    private String title;
+    private String meetingTitle;
 
     @OneToMany(mappedBy = "meeting")
-    // Cascade, orphanRemoval 사용하지 않음 → 삭제는 서비스 레이어에서 명시적으로 처리해야 함
     private List<Participant> participants = new ArrayList<>();
-
 
     @Column(name = "meeting_time", nullable = false)
     private LocalDateTime meetingTime;
-
-    @Column(name = "meeting_place", nullable = false)
-    private String meetingPlace;
 
     @Column(name = "min_ppl", nullable = false)
     private Integer minPpl;
@@ -50,28 +49,117 @@ public class Meeting {
     @Column(name = "meeting_place_name", nullable = true)
     private String meetingPlaceName;
 
-    public void setTitle(String title) {
-        this.title = title;
+    @Builder
+    private Meeting(String meetingTitle,
+                    LocalDateTime meetingTime,
+                    Integer minPpl,
+                    Integer maxPpl,
+                    Integer status,
+                    Double meetingPlaceLatitude,
+                    Double meetingPlaceLongitude,
+                    String meetingPlaceName) {
+        if (meetingTitle == null || meetingTitle.trim().isEmpty()) {
+            throw new IllegalArgumentException("Meeting title cannot be null or empty");
+        }
+        if (meetingTime.isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("Meeting time must be in the future");
+        }
+        if (minPpl < 1 || minPpl > maxPpl) {
+            throw new IllegalArgumentException("Invalid participant capacity range");
+        }
+        if (status < 1 || status > 3) {
+            throw new IllegalArgumentException("Invalid meeting status");
+        }
+        this.meetingTitle = meetingTitle;
+        this.meetingTime = meetingTime;
+        this.minPpl = minPpl;
+        this.maxPpl = maxPpl;
+        this.status = status;
+        this.meetingPlaceLatitude = meetingPlaceLatitude;
+        this.meetingPlaceLongitude = meetingPlaceLongitude;
+        this.meetingPlaceName = meetingPlaceName;
+        this.participants = new ArrayList<>();
     }
 
-    public void setPlace(String place, Double latitude, Double longitude, String placeName) {
-        this.meetingPlace = place;
+    public List<Participant> getParticipants() {
+        return Collections.unmodifiableList(participants);
+    }
+
+    public void changeTitle(String newTitle) {
+        if (newTitle == null || newTitle.trim().isEmpty()) {
+            throw new IllegalArgumentException("Meeting title cannot be null or empty");
+        }
+        this.meetingTitle = newTitle;
+    }
+
+    public void changeLocation(Double latitude, Double longitude, String placeName) {
+        if (latitude != null) {
+            if (latitude < -90 || latitude > 90) {
+                throw new IllegalArgumentException("Latitude must be between -90 and 90");
+            }
+        }
+        if (longitude != null) {
+            if (longitude < -180 || longitude > 180) {
+                throw new IllegalArgumentException("Longitude must be between -180 and 180");
+            }
+        }
+        if (placeName != null && placeName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Place name, if provided, cannot be empty");
+        }
         this.meetingPlaceLatitude = latitude;
         this.meetingPlaceLongitude = longitude;
         this.meetingPlaceName = placeName;
     }
 
-    public void setParticipantLimit(int min, int max) {
-        this.minPpl = min;
-        this.maxPpl = max;
+
+    public void changeMinimumCapacity(int newMinPpl) {
+        if (newMinPpl < 1) {
+            throw new IllegalArgumentException("Minimum people must be at least 1");
+        }
+        if (newMinPpl > this.maxPpl) {
+            throw new IllegalArgumentException("Minimum people cannot be greater than maximum people");
+        }
+        this.minPpl = newMinPpl;
     }
 
-    public void setMeetingTime(LocalDateTime newTime) {
+    public void changeMaximumCapacity(int newMaxPpl) {
+        if (newMaxPpl < this.minPpl) {
+            throw new IllegalArgumentException("Maximum people cannot be less than minimum people");
+        }
+        this.maxPpl = newMaxPpl;
+    }
+
+    public void rescheduleMeeting(LocalDateTime newTime) {
+        if (newTime.isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("Meeting time must be in the future");
+        }
         this.meetingTime = newTime;
     }
 
-    public void setStatus(int status) {
-        this.status = status;
+    public void changeStatus(int newStatus) {
+        if (newStatus < 1 || newStatus > 3) {
+            throw new IllegalArgumentException("Invalid meeting status");
+        }
+        this.status = newStatus;
     }
 
+    public void addParticipant(Participant participant) {
+        if (this.participants.size() >= this.maxPpl) {
+            throw new IllegalStateException("Cannot add more participants than maximum allowed");
+        }
+        this.participants.add(participant);
+        participant.updateMeeting(this);
+    }
+
+    public void removeParticipant(Participant participant) {
+        if (!this.participants.contains(participant)) {
+            throw new IllegalArgumentException("Participant not found in the meeting");
+        }
+        this.participants.remove(participant);
+        participant.updateMeeting(null);
+    }
+
+    public boolean isMeetingFull() {
+        return this.participants.size() >= this.maxPpl;
+    }
 }

--- a/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
@@ -1,4 +1,77 @@
 package org.glue.glue_be.meeting.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "meeting")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Meeting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meeting_id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "meeting_title", nullable = false)
+    private String title;
+
+    @OneToMany(mappedBy = "meeting")
+    // Cascade, orphanRemoval 사용하지 않음 → 삭제는 서비스 레이어에서 명시적으로 처리해야 함
+    private List<Participant> participants = new ArrayList<>();
+
+
+    @Column(name = "meeting_time", nullable = false)
+    private LocalDateTime meetingTime;
+
+    @Column(name = "meeting_place", nullable = false)
+    private String meetingPlace;
+
+    @Column(name = "min_ppl", nullable = false)
+    private Integer minPpl;
+
+    @Column(name = "max_ppl", nullable = false)
+    private Integer maxPpl;
+
+    @Column(name = "status", nullable = false)
+    private Integer status;
+
+    @Column(name = "meeting_place_latitude", nullable = true)
+    private Double meetingPlaceLatitude;
+
+    @Column(name = "meeting_place_longitude", nullable = true)
+    private Double meetingPlaceLongitude;
+
+    @Column(name = "meeting_place_name", nullable = true)
+    private String meetingPlaceName;
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setPlace(String place, Double latitude, Double longitude, String placeName) {
+        this.meetingPlace = place;
+        this.meetingPlaceLatitude = latitude;
+        this.meetingPlaceLongitude = longitude;
+        this.meetingPlaceName = placeName;
+    }
+
+    public void setParticipantLimit(int min, int max) {
+        this.minPpl = min;
+        this.maxPpl = max;
+    }
+
+    public void setMeetingTime(LocalDateTime newTime) {
+        this.meetingTime = newTime;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/org/glue/glue_be/meeting/entity/Participant.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Participant.java
@@ -1,0 +1,51 @@
+package org.glue.glue_be.meeting.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.glue.glue_be.user.entity.User;
+
+@Entity
+@Table(name = "participant")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Participant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "participant_id", updatable = false)
+    private Long id;
+
+    // Many Participants → One User
+    // User에서는 OneToMany(mappedBy = "user")로써 Participant.user 필드를 기준으로 연관관계가 매핑됨을 표현해야 함
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // Many Participants → One Meeting
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
+
+    void setMeeting(Meeting meeting) {
+        this.meeting = meeting;
+    }
+
+    void setUser(User user) {
+        this.user = user;
+    }
+
+    // 양방향 정합성을 위해
+    //    public void addParticipant(Participant participant) {
+    //        participants.add(participant);
+    //        participant.setUser(this);
+    //    }
+    //
+    //    public void addParticipant(Participant participant) {
+    //        participants.add(participant);
+    //        participant.setMeeting(this);
+    //    }
+    // 를 User, Meeting 측에 추가하면 좋을 듯
+
+}

--- a/src/main/java/org/glue/glue_be/meeting/entity/Participant.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Participant.java
@@ -5,7 +5,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.glue.glue_be.user.entity.User;
-import lombok.Builder;
 
 @Entity
 @Table(name = "participant")
@@ -18,31 +17,35 @@ public class Participant {
     @Column(name = "participant_id", updatable = false)
     private Long id;
 
+    // Many Participants → One User
+    // User에서는 OneToMany(mappedBy = "user")로써 Participant.user 필드를 기준으로 연관관계가 매핑됨을 표현해야 함
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    // Many Participants → One Meeting
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "meeting_id", nullable = false)
     private Meeting meeting;
 
-    @Builder
-    private Participant(User user, Meeting meeting) {
-        this.user = user;
+    void setMeeting(Meeting meeting) {
         this.meeting = meeting;
     }
 
-    void updateMeeting(Meeting meeting) {
-        this.meeting = meeting;
-    }
-
-    void updateUser(User user) {
+    void setUser(User user) {
         this.user = user;
     }
 
-    public void cancelParticipation() {
-        if (this.meeting != null) {
-            this.meeting.removeParticipant(this);
-        }
-    }
+    // 양방향 정합성을 위해
+    //    public void addParticipant(Participant participant) {
+    //        participants.add(participant);
+    //        participant.setUser(this);
+    //    }
+    //
+    //    public void addParticipant(Participant participant) {
+    //        participants.add(participant);
+    //        participant.setMeeting(this);
+    //    }
+    // 를 User, Meeting 측에 추가하면 좋을 듯
+
 }

--- a/src/main/java/org/glue/glue_be/meeting/entity/Participant.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Participant.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.glue.glue_be.user.entity.User;
+import lombok.Builder;
 
 @Entity
 @Table(name = "participant")
@@ -17,35 +18,31 @@ public class Participant {
     @Column(name = "participant_id", updatable = false)
     private Long id;
 
-    // Many Participants → One User
-    // User에서는 OneToMany(mappedBy = "user")로써 Participant.user 필드를 기준으로 연관관계가 매핑됨을 표현해야 함
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    // Many Participants → One Meeting
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "meeting_id", nullable = false)
     private Meeting meeting;
 
-    void setMeeting(Meeting meeting) {
+    @Builder
+    private Participant(User user, Meeting meeting) {
+        this.user = user;
         this.meeting = meeting;
     }
 
-    void setUser(User user) {
+    void updateMeeting(Meeting meeting) {
+        this.meeting = meeting;
+    }
+
+    void updateUser(User user) {
         this.user = user;
     }
 
-    // 양방향 정합성을 위해
-    //    public void addParticipant(Participant participant) {
-    //        participants.add(participant);
-    //        participant.setUser(this);
-    //    }
-    //
-    //    public void addParticipant(Participant participant) {
-    //        participants.add(participant);
-    //        participant.setMeeting(this);
-    //    }
-    // 를 User, Meeting 측에 추가하면 좋을 듯
-
+    public void cancelParticipation() {
+        if (this.meeting != null) {
+            this.meeting.removeParticipant(this);
+        }
+    }
 }


### PR DESCRIPTION
Meeting ↔ Participant 간 연관관계를 양방향 OneToMany / ManyToOne으로 설정했습니다.

Meeting.addParticipant(), Participant.setMeeting()을 통해 연관관계 정합성을 보장합니다.

Participant가 연관관계의 주인으로서 meeting_id, user_id FK를 관리하며,
User, Meeting은 각각 mappedBy를 통해 비주인으로 설정되어 있습니다.

추후 cascade/orphanRemoval은 신중하게 적용할 예정이며, 현재는 서비스 레이어에서 직접 save/delete 처리합니다.