### PR TITLE
feat: chat 도메인 관련 메서드 추가

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
@@ -17,7 +17,7 @@ public class ChatRoom {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "chatroom_id")
-	private Long id;
+	private Long chatRoomId;
 
 	// chatroom이 비즈니스적으로 meeting에 속하기 때문에 여기가 FK를 가짐
 	// cascade는 meeting과의 관계에 대해 명확히 알게되면 추가해야 할 듯

--- a/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
@@ -35,4 +35,10 @@ public class ChatRoom {
 		this.meeting = meeting;
 	}
 
+	// userChatrooms에 넣고 userChatroom의 메서드에 this를 넣어 동기화
+	public void addUserChatroom(UserChatroom userChatroom){
+		this.userChatrooms.add(userChatroom);
+		userChatroom.updateChatRoom(this);
+	}
+
 }

--- a/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/ChatRoom.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "chatroom")
 public class ChatRoom {
 

--- a/src/main/java/org/glue/glue_be/chat/entity/Message.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/Message.java
@@ -16,7 +16,7 @@ public class Message extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "message_id")
-	private Long id;
+	private Long messageId;
 
 	// Message와 User는 매개 테이블 없이 직접적인 연관관계를 매핑
 	// 따라서 반대측인 User에서 OneToMany를 작성할 필요 없음

--- a/src/main/java/org/glue/glue_be/chat/entity/Message.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/Message.java
@@ -7,7 +7,7 @@ import lombok.*;
 
 @Entity
 @Getter
-@Builder(toBuilder = true)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "message")

--- a/src/main/java/org/glue/glue_be/chat/entity/Message.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/Message.java
@@ -8,8 +8,8 @@ import lombok.*;
 @Entity
 @Getter
 @Builder(toBuilder = true)
-@AllArgsConstructor
-@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "message")
 public class Message {
 

--- a/src/main/java/org/glue/glue_be/chat/entity/Message.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/Message.java
@@ -3,15 +3,15 @@ package org.glue.glue_be.chat.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.glue.glue_be.common.BaseEntity;
+import org.glue.glue_be.user.entity.User;
 
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "message")
-public class Message {
+public class Message extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,7 +24,21 @@ public class Message {
 	@JoinColumn(name = "chatroom_id", nullable = false)
 	private ChatRoom chatRoom;
 
+	// 추후 이부분을 일반 속성인 uuid로 대체해야 할지 결정해야함
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
 	@Column(name = "message_content", columnDefinition = "TEXT", nullable = false)
 	private String messageContent;
+
+	@Builder
+	private Message(ChatRoom chatRoom, User user, String messageContent){
+		this.chatRoom = chatRoom;
+		this.user = user;
+		this.messageContent = messageContent;
+	}
+
+	public void changeMessageContent(String newMessageContent) { this.messageContent = newMessageContent; }
 
 }

--- a/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
@@ -8,7 +8,7 @@ import org.glue.glue_be.user.entity.User;
 
 @Entity
 @Getter
-@Builder(toBuilder = true)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user_chatroom")

--- a/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
@@ -32,8 +32,10 @@ public class UserChatroom extends BaseEntity {
 		this.chatRoom = chatRoom;
 	}
 
+	// user에서 쓸 양방향 동기화 메서드
 	void updateUser(User user){ this.user = user; }
 
+	// chatroom에서 쓸 양방향 동기화 메서드
 	void updateChatRoom(ChatRoom chatRoom) { this.chatRoom = chatRoom; }
 
 

--- a/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
@@ -3,16 +3,15 @@ package org.glue.glue_be.chat.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.glue.glue_be.common.BaseEntity;
 import org.glue.glue_be.user.entity.User;
 
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user_chatroom")
-public class UserChatroom {
+public class UserChatroom extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,5 +25,17 @@ public class UserChatroom {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "chatRoom_id", nullable = false)
 	private ChatRoom chatRoom;
+
+	@Builder
+	private UserChatroom(User user, ChatRoom chatRoom){
+		this.user = user;
+		this.chatRoom = chatRoom;
+	}
+
+	void updateUser(User user){ this.user = user; }
+
+	void updateChatRoom(ChatRoom chatRoom) { this.chatRoom = chatRoom; }
+
+
 
 }

--- a/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
@@ -2,18 +2,15 @@ package org.glue.glue_be.chat.entity;
 
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.glue.glue_be.user.entity.User;
 
 
 @Entity
 @Getter
 @Builder(toBuilder = true)
-@AllArgsConstructor
-@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user_chatroom")
 public class UserChatroom {
 

--- a/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/UserChatroom.java
@@ -16,7 +16,7 @@ public class UserChatroom extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "user_chatroom_id")
-	private Long id;
+	private Long userChatroomId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)


### PR DESCRIPTION
## 구현사항
- 각 엔티티별 빌더 생성자
- 관련 메서드들
- 누락된 속성들 추가(접근권한, 필드 등)

### 기타
- 일단 ManyToOne으로 유저 매핑해놨으나 추후 논의를 통해 uuid로 바꿀 수도 있어서 주석만 적어놨습니다.
- 데이터 무결성 위배가 아닌 비즈니스 로직상의 validation은 서비스 레이어에서 하기로 결정된 바에 따라 엔티티 레벨에선 validation을 명시해두지 않았습니다.


close #15 