### PR TITLE
feat: 공통응답객체 및 공통예외객체 생성

### DIFF
--- a/src/main/java/org/glue/glue_be/common/exception/BaseException.java
+++ b/src/main/java/org/glue/glue_be/common/exception/BaseException.java
@@ -1,0 +1,18 @@
+package org.glue.glue_be.common.exception;
+
+
+import lombok.Getter;
+import org.glue.glue_be.common.response.BaseResponseStatus;
+
+
+@Getter
+public class BaseException extends RuntimeException {
+
+	private final BaseResponseStatus status;
+
+
+	public BaseException(BaseResponseStatus status) {
+		this.status = status;
+	}
+
+}

--- a/src/main/java/org/glue/glue_be/common/response/BaseResponse.java
+++ b/src/main/java/org/glue/glue_be/common/response/BaseResponse.java
@@ -1,0 +1,34 @@
+package org.glue.glue_be.common.response;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+import static org.glue.glue_be.common.response.BaseResponseStatus.SUCCESS;
+
+
+public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, String message, int code, T result) {
+
+	/**
+	 * 필요값 : Http상태코드, 성공여부, 메시지, 에러코드, 결과값
+	 */
+
+	// 요청에 성공한 경우 -> return 객체가 필요한 경우
+	public BaseResponse(T result) {
+		this(
+			HttpStatus.OK, true, SUCCESS.getMessage(), SUCCESS.getCode(), result);
+	}
+
+
+	// 요청에 성공한 경우 -> return 객체가 필요 없는 경우
+	public BaseResponse() {
+		this(HttpStatus.OK, true, SUCCESS.getMessage(), SUCCESS.getCode(), null);
+	}
+
+
+	// 요청 실패한 경우
+	public BaseResponse(BaseResponseStatus status) {
+		this(status.getHttpStatusCode(), false, status.getMessage(), status.getCode(), null);
+	}
+
+}

--- a/src/main/java/org/glue/glue_be/common/response/BaseResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/common/response/BaseResponseStatus.java
@@ -1,0 +1,42 @@
+package org.glue.glue_be.common.response;
+
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+
+@Getter
+@AllArgsConstructor
+public enum BaseResponseStatus {
+
+	/**
+	 * 200: 요청 성공
+	 **/
+	SUCCESS(HttpStatus.OK, true, 200, "요청에 성공하였습니다."),
+
+	/**
+	 * 400 : security 에러
+	 */
+	WRONG_JWT_TOKEN(HttpStatus.UNAUTHORIZED, false, 401, "다시 로그인 해주세요"),
+	NO_SIGN_IN(HttpStatus.UNAUTHORIZED, false, 402, "로그인을 먼저 진행해주세요"),
+	NO_ACCESS_AUTHORITY(HttpStatus.FORBIDDEN, false, 403, "접근 권한이 없습니다"),
+
+
+	/**
+	 * 900: 기타 에러
+	 */
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 900, "Internal server error"),
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, false, 901, "잘못된 입력값입니다. 다시 확인해주세요."),
+	LOGGING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 903, "로그 기록 중 에러가 발생했습니다."),
+
+	;
+
+
+	private final HttpStatusCode httpStatusCode;
+	private final boolean isSuccess;
+	private final int code;
+	private final String message;
+}


### PR DESCRIPTION
## 구현사항
- 일관된 API 응답 및 예외처리를 위해 공통 dto입니다.

## 사용법

기본적으로 1,2번처럼 BaseResponse 컨트롤러에서, 3번처럼 BaseException은 서비스 레이어에서 쓰면 됩니다.
컨트롤러는 일반적으로 성공한 응답의 리턴을 다루고 중간에 터지는 서비스 로직상 예외, 에러는 서비스 레이어에서 발생하기 때문입니다.


1. 요청이 성공하였고 응답 body가 따로 없으면 그냥 BaseResponse 객체를 인자 없이 리턴하면 됩니다.
<img width="254" alt="image" src="https://github.com/user-attachments/assets/ddb7f2bc-571b-430d-ab00-a1d123f2732c" />  

2. 요청이 성공하였고 응답 body가 있으면 응답객체를 인자에 넣어 BaseResponse를 리턴하면 됩니다.
<img width="301" alt="image" src="https://github.com/user-attachments/assets/7bdc0a6d-0b1b-4baf-a520-4aae13d6ee30" />

3. 요청 실패 시 BaseException 객체를 리턴합니다. 
<img width="657" alt="image" src="https://github.com/user-attachments/assets/b9898a0f-a37c-4b41-a948-ec7638a7ba39" />

이때 인자는 기본응답 status로 사용자가 직접 여러 상황에 대해 지정합니다.
이 인자들이 모인 곳이 BaseResponsesStatus ENUM 클래스입니다.
각자 맡은 작업 하면서 에러 새로 만들어야 할때마다 여기에 등록하고 baseException에 집어넣어 에러처리하면 됩니다.

이를 통해 성공한 요청, 에러 등을 모두 일관된 dto 형식으로 리턴할 수 있어 디버깅 시 유용할겁니다.

