### PR TITLE
hotfix: 날짜 -> string converter 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.xerial:sqlite-jdbc:3.41.2.1' // sqlite jdbc
+	implementation 'org.xerial:sqlite-jdbc:3.41.2.2' // sqlite jdbc
     implementation 'org.hibernate.orm:hibernate-community-dialects' // sqlite3 dialect
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/org/glue/glue_be/common/BaseEntity.java
+++ b/src/main/java/org/glue/glue_be/common/BaseEntity.java
@@ -2,9 +2,12 @@ package org.glue.glue_be.common;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+
+import lombok.Getter;
 import org.springframework.data.annotation.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
 @EntityListeners(value = AuditingEntityListener.class)
 @MappedSuperclass
 abstract public class BaseEntity {

--- a/src/main/java/org/glue/glue_be/common/BaseEntity.java
+++ b/src/main/java/org/glue/glue_be/common/BaseEntity.java
@@ -2,8 +2,8 @@ package org.glue.glue_be.common;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
-
 import lombok.Getter;
+import org.glue.glue_be.common.config.LocalDateTimeStringConverter;
 import org.springframework.data.annotation.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -13,9 +13,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 abstract public class BaseEntity {
 
     @CreatedDate
+    @Convert(converter = LocalDateTimeStringConverter.class)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Convert(converter = LocalDateTimeStringConverter.class)
     private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/org/glue/glue_be/common/config/LocalDateStringConverter.java
+++ b/src/main/java/org/glue/glue_be/common/config/LocalDateStringConverter.java
@@ -1,0 +1,22 @@
+package org.glue.glue_be.common.config;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Converter(autoApply = true)
+public class LocalDateStringConverter implements AttributeConverter<LocalDate, String> {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    @Override
+    public String convertToDatabaseColumn(LocalDate attribute) {
+        return attribute != null ? attribute.format(FORMATTER) : null;
+    }
+
+    @Override
+    public LocalDate convertToEntityAttribute(String dbData) {
+        return dbData != null ? LocalDate.parse(dbData, FORMATTER) : null;
+    }
+}

--- a/src/main/java/org/glue/glue_be/common/config/LocalDateTimeStringConverter.java
+++ b/src/main/java/org/glue/glue_be/common/config/LocalDateTimeStringConverter.java
@@ -1,0 +1,24 @@
+package org.glue.glue_be.common.config;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Converter
+public class LocalDateTimeStringConverter implements AttributeConverter<LocalDateTime, String> {
+
+    @Override
+    public String convertToDatabaseColumn(LocalDateTime attribute) {
+        return attribute != null ? attribute.toString() : null;
+    }
+
+    @Override
+    public LocalDateTime convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null; // 또는 기본값을 반환
+        }
+        return LocalDateTime.parse(dbData, DateTimeFormatter.ISO_DATE_TIME);
+    }
+
+}

--- a/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
@@ -6,6 +6,9 @@ import lombok.NoArgsConstructor;
 import lombok.AccessLevel;
 import lombok.Builder;
 import org.glue.glue_be.common.BaseEntity;
+import org.glue.glue_be.common.config.LocalDateTimeStringConverter;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,6 +32,7 @@ public class Meeting extends BaseEntity {
     private List<Participant> participants = new ArrayList<>();
 
     @Column(name = "meeting_time", nullable = false)
+    @Convert(converter = LocalDateTimeStringConverter.class)
     private LocalDateTime meetingTime;
 
     @Column(name = "current_participants", nullable = false)

--- a/src/main/java/org/glue/glue_be/post/entity/Post.java
+++ b/src/main/java/org/glue/glue_be/post/entity/Post.java
@@ -3,6 +3,7 @@ package org.glue.glue_be.post.entity;
 import lombok.*;
 
 import jakarta.persistence.*;
+import org.glue.glue_be.common.config.LocalDateTimeStringConverter;
 import org.glue.glue_be.meeting.entity.Meeting;
 
 import java.time.LocalDateTime;
@@ -33,6 +34,7 @@ public class Post {
     private Integer viewCount;
 
     @Column(name = "bumped_at", nullable = true)
+    @Convert(converter = LocalDateTimeStringConverter.class)
     private LocalDateTime bumpedAt;
 
     @OneToMany(mappedBy = "post")

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import lombok.*;
 import org.glue.glue_be.common.BaseEntity;
+import org.glue.glue_be.common.config.LocalDateStringConverter;
 
 @Getter
 @Entity
@@ -34,6 +35,7 @@ public class User extends BaseEntity {
     private Integer gender;
 
     @Column(name = "birth_date", nullable = false)
+    @Convert(converter = LocalDateStringConverter.class)
     private LocalDate birthDate;
 
     // TODO: 언어로 할 거면 변경 필요 (+ 함수도)


### PR DESCRIPTION
## What?

- `LocalDateTimeStringConverter` 클래스와 `LocalDateStringConverter` 클래스를 만들었습니다.
- `LocalDateTimeStringConverter`는 시간대까지 필요한 엔티티의 속성에, `LocalDateStringConverter`는 날짜만 필요한 엔티티의 속성에 적용했습니다.
(날짜만 필요한 건 생일 뿐이어서, 생일을 제외한 나머지는 모두 `LocalDateTimeStringConverter`를 적용했다고 생각해도 무방합니다.)
- 기타등등 필요한 것들 적용했습니다.
(BaseEntity에 @Getter 추가, jdbc 버전 업데이트)

## Why?

- sqlite는 TEXT, INTEGER, REAL 등의 기본 타입만 지원하며, LocalDateTime과 같은 복합 타입은 직접 저장할 수 없습니다.
- 따라서 LocalDateTime을 ISO-8601 형식의 문자열(yyyy-MM-dd'T'HH:mm:ss)로 변환해 저장하고, 다시 불러올 때 문자열을 LocalDateTime으로 역변환해야 합니다.
- 제가 이거 때문에 3시간은 날려 먹은 거 같아서(ㅠㅠ) 모두가 똑같은 문제를 겪지 않게 하기 위해 hotfix로 올리고 바로 머지했습니다.

## How?

<img width="476" alt="image" src="https://github.com/user-attachments/assets/1556fea9-498c-4c5b-9c53-729765c2714c" />

- 사진과 같이 @Convert를 사용하면 됩니다.

<img width="424" alt="image" src="https://github.com/user-attachments/assets/92b24937-d540-4dbe-b35d-983bbeb92e6b" />

- 데이터를 저장할 땐, 시간이 필요없는 경우는 왼쪽처럼, 시간이 필요한 경우는 오른쪽처럼 저장됩니다.
- 임의로 테스트 데이터를 테이블에 넣을 때도 위의 형식을 정확히 지켜서 넣어야 날짜 파싱 오류가 나지 않습니다.