### PR TITLE
feat:모임 생성, 초대장 기능 및 예외/응답 구조 리팩토링

### DIFF
--- a/src/main/java/org/glue/glue_be/common/exception/BaseException.java
+++ b/src/main/java/org/glue/glue_be/common/exception/BaseException.java
@@ -1,18 +1,28 @@
 package org.glue.glue_be.common.exception;
 
-
 import lombok.Getter;
-import org.glue.glue_be.common.response.BaseResponseStatus;
-
+import org.glue.glue_be.common.response.ResponseStatus;
 
 @Getter
 public class BaseException extends RuntimeException {
 
-	private final BaseResponseStatus status;
+	private final ResponseStatus status;
+	private final String detailMessage;
 
-
-	public BaseException(BaseResponseStatus status) {
+	public BaseException(ResponseStatus status) {
+		super(status.getMessage());
 		this.status = status;
+		this.detailMessage = status.getMessage();
 	}
 
+	public BaseException(ResponseStatus status, String detailMessage) {
+		super(detailMessage);
+		this.status = status;
+		this.detailMessage = detailMessage;
+	}
+	
+	@Override
+	public String getMessage() {
+		return detailMessage;
+	}
 }

--- a/src/main/java/org/glue/glue_be/common/response/BaseResponse.java
+++ b/src/main/java/org/glue/glue_be/common/response/BaseResponse.java
@@ -1,11 +1,9 @@
 package org.glue.glue_be.common.response;
 
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 
 import static org.glue.glue_be.common.response.BaseResponseStatus.SUCCESS;
-
 
 public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, String message, int code, T result) {
 
@@ -19,16 +17,18 @@ public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, Stri
 			HttpStatus.OK, true, SUCCESS.getMessage(), SUCCESS.getCode(), result);
 	}
 
-
 	// 요청에 성공한 경우 -> return 객체가 필요 없는 경우
 	public BaseResponse() {
 		this(HttpStatus.OK, true, SUCCESS.getMessage(), SUCCESS.getCode(), null);
 	}
 
-
-	// 요청 실패한 경우
-	public BaseResponse(BaseResponseStatus status) {
-		this(status.getHttpStatusCode(), false, status.getMessage(), status.getCode(), null);
+	// 요청 실패한 경우 (모든 ResponseStatus 구현체 사용 가능)
+	public BaseResponse(ResponseStatus status) {
+		this(status.getHttpStatusCode(), status.isSuccess(), status.getMessage(), status.getCode(), null);
 	}
-
+	
+	// 요청 실패한 경우 (상세 메시지 포함)
+	public BaseResponse(ResponseStatus status, String detailMessage) {
+		this(status.getHttpStatusCode(), status.isSuccess(), detailMessage, status.getCode(), null);
+	}
 }

--- a/src/main/java/org/glue/glue_be/common/response/BaseResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/common/response/BaseResponseStatus.java
@@ -1,16 +1,13 @@
 package org.glue.glue_be.common.response;
 
-
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 
-
 @Getter
 @AllArgsConstructor
-public enum BaseResponseStatus {
+public enum BaseResponseStatus implements ResponseStatus {
 
 	/**
 	 * 200: 요청 성공
@@ -23,17 +20,14 @@ public enum BaseResponseStatus {
 	WRONG_JWT_TOKEN(HttpStatus.UNAUTHORIZED, false, 401, "다시 로그인 해주세요"),
 	NO_SIGN_IN(HttpStatus.UNAUTHORIZED, false, 402, "로그인을 먼저 진행해주세요"),
 	NO_ACCESS_AUTHORITY(HttpStatus.FORBIDDEN, false, 403, "접근 권한이 없습니다"),
-
+	FORBIDDEN(HttpStatus.FORBIDDEN, false, 404, "권한이 없습니다"),
 
 	/**
 	 * 900: 기타 에러
 	 */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 900, "Internal server error"),
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, false, 901, "잘못된 입력값입니다. 다시 확인해주세요."),
-	LOGGING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 903, "로그 기록 중 에러가 발생했습니다."),
-
-	;
-
+	LOGGING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 903, "로그 기록 중 에러가 발생했습니다.");
 
 	private final HttpStatusCode httpStatusCode;
 	private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/common/response/ResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/common/response/ResponseStatus.java
@@ -1,0 +1,13 @@
+package org.glue.glue_be.common.response;
+
+import org.springframework.http.HttpStatusCode;
+
+/**
+ * 모든 응답 상태 enum이 구현해야 하는 인터페이스
+ */
+public interface ResponseStatus {
+    HttpStatusCode getHttpStatusCode();
+    boolean isSuccess();
+    int getCode();
+    String getMessage();
+} 

--- a/src/main/java/org/glue/glue_be/invitation/controller/InvitationController.java
+++ b/src/main/java/org/glue/glue_be/invitation/controller/InvitationController.java
@@ -1,0 +1,64 @@
+package org.glue.glue_be.invitation.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.common.response.BaseResponse;
+import org.glue.glue_be.invitation.dto.InvitationDto;
+import org.glue.glue_be.invitation.service.InvitationService;
+import org.glue.glue_be.meeting.dto.MeetingDto;
+import org.glue.glue_be.meeting.service.MeetingService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/invitations")
+public class InvitationController {
+
+    private final InvitationService invitationService;
+    private final MeetingService meetingService;
+    
+    /**
+     * 모임 초대장 생성 API
+     */
+    @PostMapping("/meeting/{meetingId}")
+    public BaseResponse<InvitationDto.Response> createMeetingInvitation(
+            @PathVariable Long meetingId, 
+            @Valid @RequestBody MeetingDto.InvitationRequest request) {
+        Long currentUserId = getCurrentUserId();
+        return new BaseResponse<>(meetingService.createMeetingInvitation(meetingId, request.getInviteeId(), currentUserId));
+    }
+    
+    /**
+     * 초대장 수락 API
+     */
+    @PostMapping("/accept")
+    public BaseResponse<Void> acceptInvitation(@RequestBody InvitationDto.AcceptRequest request) {
+        Long currentUserId = getCurrentUserId();
+        invitationService.acceptInvitation(request.getCode(), currentUserId);
+        return new BaseResponse<>();
+    }
+    
+    /**
+     * 초대장 목록 조회 API
+     */
+    @GetMapping
+    public BaseResponse<Page<InvitationDto.Response>> getInvitations(Pageable pageable) {
+        Long currentUserId = getCurrentUserId();
+        return new BaseResponse<>(invitationService.getInvitations(currentUserId, pageable));
+    }
+    
+    /**
+     * 현재 로그인한 사용자 ID 가져오기
+     */
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new IllegalStateException("인증 정보를 찾을 수 없습니다.");
+        }
+        return Long.parseLong(authentication.getPrincipal().toString());
+    }
+} 

--- a/src/main/java/org/glue/glue_be/invitation/controller/InvitationController.java
+++ b/src/main/java/org/glue/glue_be/invitation/controller/InvitationController.java
@@ -21,9 +21,7 @@ public class InvitationController {
     private final InvitationService invitationService;
     private final MeetingService meetingService;
     
-    /**
-     * 모임 초대장 생성 API
-     */
+    // 모임 초대장 생성 API
     @PostMapping("/meeting/{meetingId}")
     public BaseResponse<InvitationDto.Response> createMeetingInvitation(
             @PathVariable Long meetingId, 
@@ -32,9 +30,7 @@ public class InvitationController {
         return new BaseResponse<>(meetingService.createMeetingInvitation(meetingId, request.getInviteeId(), currentUserId));
     }
     
-    /**
-     * 초대장 수락 API
-     */
+    // 초대장 수락 API
     @PostMapping("/accept")
     public BaseResponse<Void> acceptInvitation(@RequestBody InvitationDto.AcceptRequest request) {
         Long currentUserId = getCurrentUserId();
@@ -42,18 +38,14 @@ public class InvitationController {
         return new BaseResponse<>();
     }
     
-    /**
-     * 초대장 목록 조회 API
-     */
+    // 초대장 목록 조회 API
     @GetMapping
     public BaseResponse<Page<InvitationDto.Response>> getInvitations(Pageable pageable) {
         Long currentUserId = getCurrentUserId();
         return new BaseResponse<>(invitationService.getInvitations(currentUserId, pageable));
     }
     
-    /**
-     * 현재 로그인한 사용자 ID 가져오기
-     */
+    // 현재 로그인한 사용자 ID 가져오기
     private Long getCurrentUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || authentication.getPrincipal() == null) {
@@ -61,4 +53,4 @@ public class InvitationController {
         }
         return Long.parseLong(authentication.getPrincipal().toString());
     }
-} 
+}

--- a/src/main/java/org/glue/glue_be/invitation/controller/InvitationController.java
+++ b/src/main/java/org/glue/glue_be/invitation/controller/InvitationController.java
@@ -6,7 +6,6 @@ import org.glue.glue_be.common.response.BaseResponse;
 import org.glue.glue_be.invitation.dto.InvitationDto;
 import org.glue.glue_be.invitation.service.InvitationService;
 import org.glue.glue_be.meeting.dto.MeetingDto;
-import org.glue.glue_be.meeting.service.MeetingService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 public class InvitationController {
 
     private final InvitationService invitationService;
-    private final MeetingService meetingService;
     
     // 모임 초대장 생성 API
     @PostMapping("/meeting/{meetingId}")
@@ -27,7 +25,16 @@ public class InvitationController {
             @PathVariable Long meetingId, 
             @Valid @RequestBody MeetingDto.InvitationRequest request) {
         Long currentUserId = getCurrentUserId();
-        return new BaseResponse<>(meetingService.createMeetingInvitation(meetingId, request.getInviteeId(), currentUserId));
+        
+        // InvitationService에 필요한 데이터 구성
+        InvitationDto.CreateRequest invitationRequest = InvitationDto.CreateRequest.builder()
+                .meetingId(meetingId)
+                .inviteeId(request.getInviteeId())
+                .maxUses(1) // 기본값: 한 번만 사용 가능
+                .expirationHours(6) // 기본값: 6시간 유효
+                .build();
+        
+        return new BaseResponse<>(invitationService.createInvitation(invitationRequest, currentUserId));
     }
     
     // 초대장 수락 API

--- a/src/main/java/org/glue/glue_be/invitation/dto/InvitationDto.java
+++ b/src/main/java/org/glue/glue_be/invitation/dto/InvitationDto.java
@@ -1,5 +1,7 @@
 package org.glue.glue_be.invitation.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,9 +14,10 @@ public class InvitationDto {
     @Getter
     @Setter
     @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class CreateRequest {
         private Integer maxUses;
-        private Integer expirationDays;
         private Integer expirationHours;
         private Long meetingId;
         private Long inviteeId;
@@ -44,7 +47,7 @@ public class InvitationDto {
             response.maxUses = invitation.getMaxUses();
             response.usedCount = invitation.getUsedCount();
             response.status = invitation.getStatus();
-            response.meetingId = invitation.getMeetingId();
+            response.meetingId = invitation.getMeeting() != null ? invitation.getMeeting().getMeetingId() : null;
             response.inviteeId = invitation.getInviteeId();
             return response;
         }

--- a/src/main/java/org/glue/glue_be/invitation/dto/InvitationDto.java
+++ b/src/main/java/org/glue/glue_be/invitation/dto/InvitationDto.java
@@ -1,0 +1,58 @@
+package org.glue.glue_be.invitation.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.glue.glue_be.invitation.entity.Invitation;
+
+import java.time.LocalDateTime;
+
+public class InvitationDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class CreateRequest {
+        private Integer maxUses;
+        private Integer expirationDays;
+        private Integer expirationHours;
+        private Long meetingId;
+        private Long inviteeId;
+        
+        public void setMeetingId(Long meetingId) {
+            this.meetingId = meetingId;
+        }
+    }
+    
+    @Getter
+    @NoArgsConstructor
+    public static class Response {
+        private Long invitationId;
+        private String code;
+        private LocalDateTime expiresAt;
+        private Integer maxUses;
+        private Integer usedCount;
+        private Integer status;
+        private Long meetingId;
+        private Long inviteeId;
+        
+        public static Response from(Invitation invitation) {
+            Response response = new Response();
+            response.invitationId = invitation.getInvitationId();
+            response.code = invitation.getCode();
+            response.expiresAt = invitation.getExpiresAt();
+            response.maxUses = invitation.getMaxUses();
+            response.usedCount = invitation.getUsedCount();
+            response.status = invitation.getStatus();
+            response.meetingId = invitation.getMeetingId();
+            response.inviteeId = invitation.getInviteeId();
+            return response;
+        }
+    }
+    
+    @Getter
+    @NoArgsConstructor
+    public static class AcceptRequest {
+        private String code;
+    }
+} 

--- a/src/main/java/org/glue/glue_be/invitation/entity/Invitation.java
+++ b/src/main/java/org/glue/glue_be/invitation/entity/Invitation.java
@@ -70,7 +70,7 @@ public class Invitation extends BaseEntity {
     public boolean canBeUsedBy(Long userId) {
         return !isForSpecificUser() || inviteeId.equals(userId);
     }
-    
+    // 초대장을 여러 번 사용할 수도 있을 것 같아서, 최대 사용 횟수를 유연하게 조절할 수 있도록 코드를 짜둔 상태
     public void incrementUsedCount() {
         this.usedCount++;
         if (this.usedCount >= this.maxUses) {

--- a/src/main/java/org/glue/glue_be/invitation/entity/Invitation.java
+++ b/src/main/java/org/glue/glue_be/invitation/entity/Invitation.java
@@ -1,0 +1,82 @@
+package org.glue.glue_be.invitation.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.glue.glue_be.common.BaseEntity;
+import org.glue.glue_be.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "invitation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Invitation extends BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "invitation_id")
+    private Long invitationId;
+    
+    @Column(name = "code", nullable = false, unique = true)
+    private String code;
+    
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+    
+    @Column(name = "max_uses", nullable = false)
+    private Integer maxUses;
+    
+    @Column(name = "used_count", nullable = false)
+    private Integer usedCount = 0;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id", nullable = false)
+    private User creator;
+    
+    @Column(name = "status", nullable = false)
+    private Integer status = 1; // 1: ACTIVE, 2: EXPIRED, 3: FULLY_USED
+    
+    @Column(name = "meeting_id", nullable = false)
+    private Long meetingId;
+    
+    @Column(name = "invitee_id", nullable = true)
+    private Long inviteeId; // 초대장을 수락할 수 있는 사용자 ID
+    
+    @Builder
+    private Invitation(String code, LocalDateTime expiresAt, Integer maxUses, User creator, Long meetingId, Long inviteeId) {
+        this.code = code;
+        this.expiresAt = expiresAt;
+        this.maxUses = maxUses;
+        this.creator = creator;
+        this.usedCount = 0;
+        this.status = 1;
+        this.meetingId = meetingId;
+        this.inviteeId = inviteeId;
+    }
+    
+    public boolean isValid() {
+        return status == 1 && LocalDateTime.now().isBefore(expiresAt) && usedCount < maxUses;
+    }
+    
+    // 특정 사용자만 사용할 수 있는 초대장인지 확인
+    public boolean isForSpecificUser() {
+        return inviteeId != null;
+    }
+    
+    // 특정 사용자가 초대장을 사용할 수 있는지 확인
+    public boolean canBeUsedBy(Long userId) {
+        return !isForSpecificUser() || inviteeId.equals(userId);
+    }
+    
+    public void incrementUsedCount() {
+        this.usedCount++;
+        if (this.usedCount >= this.maxUses) {
+            this.status = 3; // FULLY_USED
+        }
+    }
+    
+    public void expire() {
+        this.status = 2; // EXPIRED
+    }
+} 

--- a/src/main/java/org/glue/glue_be/invitation/entity/Invitation.java
+++ b/src/main/java/org/glue/glue_be/invitation/entity/Invitation.java
@@ -3,6 +3,7 @@ package org.glue.glue_be.invitation.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.glue.glue_be.common.BaseEntity;
+import org.glue.glue_be.meeting.entity.Meeting;
 import org.glue.glue_be.user.entity.User;
 
 import java.time.LocalDateTime;
@@ -45,14 +46,14 @@ public class Invitation extends BaseEntity {
     private Long inviteeId; // 초대장을 수락할 수 있는 사용자 ID
     
     @Builder
-    private Invitation(String code, LocalDateTime expiresAt, Integer maxUses, User creator, Long meetingId, Long inviteeId) {
+    private Invitation(String code, LocalDateTime expiresAt, Integer maxUses, User creator, Meeting meeting, Long inviteeId) {
         this.code = code;
         this.expiresAt = expiresAt;
         this.maxUses = maxUses;
         this.creator = creator;
         this.usedCount = 0;
         this.status = 1;
-        this.meetingId = meetingId;
+        this.meeting = meeting;
         this.inviteeId = inviteeId;
     }
     

--- a/src/main/java/org/glue/glue_be/invitation/entity/Invitation.java
+++ b/src/main/java/org/glue/glue_be/invitation/entity/Invitation.java
@@ -37,8 +37,9 @@ public class Invitation extends BaseEntity {
     @Column(name = "status", nullable = false)
     private Integer status = 1; // 1: ACTIVE, 2: EXPIRED, 3: FULLY_USED
     
-    @Column(name = "meeting_id", nullable = false)
-    private Long meetingId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id")
+    private Meeting meeting;
     
     @Column(name = "invitee_id", nullable = true)
     private Long inviteeId; // 초대장을 수락할 수 있는 사용자 ID

--- a/src/main/java/org/glue/glue_be/invitation/repository/InvitationRepository.java
+++ b/src/main/java/org/glue/glue_be/invitation/repository/InvitationRepository.java
@@ -1,0 +1,24 @@
+package org.glue.glue_be.invitation.repository;
+
+import jakarta.persistence.LockModeType;
+import org.glue.glue_be.invitation.entity.Invitation;
+import org.glue.glue_be.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+    
+    Optional<Invitation> findByCode(String code);
+    
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT i FROM Invitation i WHERE i.code = :code")
+    Optional<Invitation> findByCodeWithLock(@Param("code") String code);
+    
+    Page<Invitation> findByCreator(User creator, Pageable pageable);
+} 

--- a/src/main/java/org/glue/glue_be/invitation/response/InvitationResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/invitation/response/InvitationResponseStatus.java
@@ -1,0 +1,27 @@
+package org.glue.glue_be.invitation.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.glue.glue_be.common.response.ResponseStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum InvitationResponseStatus implements ResponseStatus {
+    
+    /**
+     * 초대장 관련 에러
+     */
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, false, 601, "초대장을 찾을 수 없습니다"),
+    INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, false, 602, "만료된 초대장입니다"),
+    INVITATION_FULLY_USED(HttpStatus.BAD_REQUEST, false, 603, "최대 사용 인원을 초과했습니다"),
+    INVITATION_INVALID(HttpStatus.BAD_REQUEST, false, 604, "유효하지 않은 초대장입니다"),
+    INVITATION_ALREADY_JOINED(HttpStatus.BAD_REQUEST, false, 605, "이미 참여한 미팅입니다"),
+    INVITATION_NOT_FOR_USER(HttpStatus.FORBIDDEN, false, 606, "이 초대장은 다른 사용자를 위한 것입니다");
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+} 

--- a/src/main/java/org/glue/glue_be/invitation/service/InvitationService.java
+++ b/src/main/java/org/glue/glue_be/invitation/service/InvitationService.java
@@ -23,8 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
-import java.lang.reflect.Field;
-import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -40,35 +38,9 @@ public class InvitationService {
      */
     @Transactional
     public InvitationDto.Response createInvitation(InvitationDto.CreateRequest request, Long creatorId) {
-        // 실제 데이터베이스 조회를 시도
-        User creator;
-        try {
-            creator = userRepository.findById(creatorId)
-                    .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
-        } catch (Exception e) {
-            // 데이터베이스 조회 실패 시 임시 사용자 생성 (개발 환경에서만 사용)
-            creator = User.builder()
-                    .uuid(UUID.randomUUID())
-                    .oauthId(12345L)
-                    .userName("testUser")
-                    .nickname("testUser")
-                    .gender(1)
-                    .birth(LocalDate.of(2000, 1, 1))
-                    .nation(1)
-                    .certified(0)
-                    .major(1)
-                    .majorVisibility(1)
-                    .build();
-                    
-            // UserId 설정 시도 (Optional)
-            try {
-                Field userIdField = User.class.getDeclaredField("userId");
-                userIdField.setAccessible(true);
-                userIdField.set(creator, creatorId);
-            } catch (Exception ex) {
-                // 무시
-            }
-        }
+        // 사용자 조회
+        User creator = userRepository.findById(creatorId)
+                .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
         
         // 미팅 존재 확인 
         if (request.getMeetingId() == null) {
@@ -123,35 +95,9 @@ public class InvitationService {
         Invitation invitation = invitationRepository.findByCodeWithLock(code)
                 .orElseThrow(() -> new BaseException(InvitationResponseStatus.INVITATION_NOT_FOUND));
         
-        // 실제 데이터베이스 조회를 시도
-        User user;
-        try {
-            user = userRepository.findById(userId)
-                    .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
-        } catch (Exception e) {
-            // 데이터베이스 조회 실패 시 임시 사용자 생성 (개발 환경에서만 사용)
-            user = User.builder()
-                    .uuid(UUID.randomUUID())
-                    .oauthId(12345L)
-                    .userName("testUser")
-                    .nickname("testUser")
-                    .gender(1)
-                    .birth(LocalDate.of(2000, 1, 1))
-                    .nation(1)
-                    .certified(0)
-                    .major(1)
-                    .majorVisibility(1)
-                    .build();
-                    
-            // UserId 설정 시도 (Optional)
-            try {
-                Field userIdField = User.class.getDeclaredField("userId");
-                userIdField.setAccessible(true);
-                userIdField.set(user, userId);
-            } catch (Exception ex) {
-                // 무시
-            }
-        }
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
         
         // 초대장 유효성 검사
         if (!invitation.isValid()) {
@@ -204,35 +150,9 @@ public class InvitationService {
      */
     @Transactional(readOnly = true)
     public Page<InvitationDto.Response> getInvitations(Long creatorId, Pageable pageable) {
-        // 실제 데이터베이스 조회를 시도
-        User creator;
-        try {
-            creator = userRepository.findById(creatorId)
-                    .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
-        } catch (Exception e) {
-            // 데이터베이스 조회 실패 시 임시 사용자 생성 (개발 환경에서만 사용)
-            creator = User.builder()
-                    .uuid(UUID.randomUUID())
-                    .oauthId(12345L)
-                    .userName("testUser")
-                    .nickname("testUser")
-                    .gender(1)
-                    .birth(LocalDate.of(2000, 1, 1))
-                    .nation(1)
-                    .certified(0)
-                    .major(1)
-                    .majorVisibility(1)
-                    .build();
-                    
-            // UserId 설정 시도 (Optional)
-            try {
-                Field userIdField = User.class.getDeclaredField("userId");
-                userIdField.setAccessible(true);
-                userIdField.set(creator, creatorId);
-            } catch (Exception ex) {
-                // 무시
-            }
-        }
+        // 사용자 조회
+        User creator = userRepository.findById(creatorId)
+                .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
         
         return invitationRepository.findByCreator(creator, pageable)
                 .map(InvitationDto.Response::from);

--- a/src/main/java/org/glue/glue_be/invitation/service/InvitationService.java
+++ b/src/main/java/org/glue/glue_be/invitation/service/InvitationService.java
@@ -1,0 +1,247 @@
+package org.glue.glue_be.invitation.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.common.exception.BaseException;
+import org.glue.glue_be.common.response.BaseResponseStatus;
+import org.glue.glue_be.invitation.dto.InvitationDto;
+import org.glue.glue_be.invitation.entity.Invitation;
+import org.glue.glue_be.invitation.repository.InvitationRepository;
+import org.glue.glue_be.invitation.response.InvitationResponseStatus;
+import org.glue.glue_be.meeting.entity.Meeting;
+import org.glue.glue_be.meeting.entity.Participant;
+import org.glue.glue_be.meeting.repository.MeetingRepository;
+import org.glue.glue_be.meeting.repository.ParticipantRepository;
+import org.glue.glue_be.meeting.response.MeetingResponseStatus;
+import org.glue.glue_be.user.entity.User;
+import org.glue.glue_be.user.repository.UserRepository;
+import org.glue.glue_be.user.response.UserResponseStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class InvitationService {
+
+    private final InvitationRepository invitationRepository;
+    private final UserRepository userRepository;
+    private final MeetingRepository meetingRepository;
+    private final ParticipantRepository participantRepository;
+    
+    /**
+     * 미팅 초대장 생성
+     */
+    @Transactional
+    public InvitationDto.Response createInvitation(InvitationDto.CreateRequest request, Long creatorId) {
+        // 실제 데이터베이스 조회를 시도
+        User creator;
+        try {
+            creator = userRepository.findById(creatorId)
+                    .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
+        } catch (Exception e) {
+            // 데이터베이스 조회 실패 시 임시 사용자 생성 (개발 환경에서만 사용)
+            creator = User.builder()
+                    .uuid(UUID.randomUUID())
+                    .oauthId(12345L)
+                    .userName("testUser")
+                    .nickname("testUser")
+                    .gender(1)
+                    .birth(LocalDate.of(2000, 1, 1))
+                    .nation(1)
+                    .certified(0)
+                    .major(1)
+                    .majorVisibility(1)
+                    .build();
+                    
+            // UserId 설정 시도 (Optional)
+            try {
+                Field userIdField = User.class.getDeclaredField("userId");
+                userIdField.setAccessible(true);
+                userIdField.set(creator, creatorId);
+            } catch (Exception ex) {
+                // 무시
+            }
+        }
+        
+        // 미팅 존재 확인 
+        if (request.getMeetingId() == null) {
+            throw new BaseException(BaseResponseStatus.INVALID_INPUT_VALUE, "미팅 ID는 필수입니다");
+        }
+        
+        Meeting meeting = meetingRepository.findById(request.getMeetingId())
+                .orElseThrow(() -> new BaseException(MeetingResponseStatus.MEETING_NOT_FOUND));
+        
+        // inviteeId가 있는 경우 해당 사용자가 유효한지 확인
+        if (request.getInviteeId() != null) {
+            userRepository.findById(request.getInviteeId())
+                    .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND, "초대할 사용자를 찾을 수 없습니다"));
+        }
+        
+        String code = generateUniqueCode();
+        
+        // expiresAt 계산
+        LocalDateTime expiresAt = LocalDateTime.now();
+        
+        if (request.getExpirationDays() != null && request.getExpirationDays() > 0) {
+            expiresAt = expiresAt.plusDays(request.getExpirationDays());
+        }
+        
+        if (request.getExpirationHours() != null && request.getExpirationHours() > 0) {
+            expiresAt = expiresAt.plusHours(request.getExpirationHours());
+        }
+        
+        // 기본값: 기본 만료 시간이 설정되지 않은 경우 24시간으로 설정
+        if (request.getExpirationDays() == null && request.getExpirationHours() == null) {
+            expiresAt = expiresAt.plusDays(1);
+        }
+        
+        Invitation invitation = Invitation.builder()
+                .code(code)
+                .expiresAt(expiresAt)
+                .maxUses(request.getMaxUses())
+                .creator(creator)
+                .meetingId(request.getMeetingId())
+                .inviteeId(request.getInviteeId())
+                .build();
+        
+        return InvitationDto.Response.from(invitationRepository.save(invitation));
+    }
+    
+    /**
+     * 미팅 초대장 수락
+     */
+    @Transactional
+    public void acceptInvitation(String code, Long userId) {
+        // 비관적 락을 사용하여 동시성 제어
+        Invitation invitation = invitationRepository.findByCodeWithLock(code)
+                .orElseThrow(() -> new BaseException(InvitationResponseStatus.INVITATION_NOT_FOUND));
+        
+        // 실제 데이터베이스 조회를 시도
+        User user;
+        try {
+            user = userRepository.findById(userId)
+                    .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
+        } catch (Exception e) {
+            // 데이터베이스 조회 실패 시 임시 사용자 생성 (개발 환경에서만 사용)
+            user = User.builder()
+                    .uuid(UUID.randomUUID())
+                    .oauthId(12345L)
+                    .userName("testUser")
+                    .nickname("testUser")
+                    .gender(1)
+                    .birth(LocalDate.of(2000, 1, 1))
+                    .nation(1)
+                    .certified(0)
+                    .major(1)
+                    .majorVisibility(1)
+                    .build();
+                    
+            // UserId 설정 시도 (Optional)
+            try {
+                Field userIdField = User.class.getDeclaredField("userId");
+                userIdField.setAccessible(true);
+                userIdField.set(user, userId);
+            } catch (Exception ex) {
+                // 무시
+            }
+        }
+        
+        // 초대장 유효성 검사
+        if (!invitation.isValid()) {
+            if (LocalDateTime.now().isAfter(invitation.getExpiresAt())) {
+                throw new BaseException(InvitationResponseStatus.INVITATION_EXPIRED);
+            } else if (invitation.getUsedCount() >= invitation.getMaxUses()) {
+                throw new BaseException(InvitationResponseStatus.INVITATION_FULLY_USED);
+            } else {
+                throw new BaseException(InvitationResponseStatus.INVITATION_INVALID);
+            }
+        }
+        
+        // 특정 사용자를 위한 초대장인 경우, 해당 사용자만 사용 가능하도록 체크
+        if (!invitation.canBeUsedBy(userId)) {
+            throw new BaseException(InvitationResponseStatus.INVITATION_NOT_FOR_USER);
+        }
+        
+        // 초대장 사용 횟수 증가
+        invitation.incrementUsedCount();
+        
+        // 미팅 처리
+        Meeting meeting = meetingRepository.findById(invitation.getMeetingId())
+                .orElseThrow(() -> new BaseException(MeetingResponseStatus.MEETING_NOT_FOUND));
+        
+        // 미팅이 꽉 찬 경우 체크
+        if (meeting.isMeetingFull()) {
+            throw new BaseException(MeetingResponseStatus.MEETING_FULL);
+        }
+        
+        // 이미 참여한 사용자인지 체크
+        if (participantRepository.existsByUserAndMeeting(user, meeting)) {
+            throw new BaseException(InvitationResponseStatus.INVITATION_ALREADY_JOINED);  // 이미 참여 중
+        }
+        
+        // 참가자 추가
+        Participant participant = Participant.builder()
+                .user(user)
+                .meeting(meeting)
+                .build();
+        
+        participantRepository.save(participant);
+        meeting.addParticipant(participant);
+        
+        // 현재 참여자 수 업데이트
+        meeting.changeStatus(1);  // 1: 활성화
+    }
+    
+    /**
+     * 초대장 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<InvitationDto.Response> getInvitations(Long creatorId, Pageable pageable) {
+        // 실제 데이터베이스 조회를 시도
+        User creator;
+        try {
+            creator = userRepository.findById(creatorId)
+                    .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
+        } catch (Exception e) {
+            // 데이터베이스 조회 실패 시 임시 사용자 생성 (개발 환경에서만 사용)
+            creator = User.builder()
+                    .uuid(UUID.randomUUID())
+                    .oauthId(12345L)
+                    .userName("testUser")
+                    .nickname("testUser")
+                    .gender(1)
+                    .birth(LocalDate.of(2000, 1, 1))
+                    .nation(1)
+                    .certified(0)
+                    .major(1)
+                    .majorVisibility(1)
+                    .build();
+                    
+            // UserId 설정 시도 (Optional)
+            try {
+                Field userIdField = User.class.getDeclaredField("userId");
+                userIdField.setAccessible(true);
+                userIdField.set(creator, creatorId);
+            } catch (Exception ex) {
+                // 무시
+            }
+        }
+        
+        return invitationRepository.findByCreator(creator, pageable)
+                .map(InvitationDto.Response::from);
+    }
+    
+    /**
+     * 고유한 초대 코드 생성
+     */
+    private String generateUniqueCode() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+} 

--- a/src/main/java/org/glue/glue_be/invitation/service/InvitationService.java
+++ b/src/main/java/org/glue/glue_be/invitation/service/InvitationService.java
@@ -33,9 +33,9 @@ public class InvitationService {
     private final MeetingRepository meetingRepository;
     private final ParticipantRepository participantRepository;
     
-    /**
-     * 미팅 초대장 생성
-     */
+    
+    //미팅 초대장 생성
+     
     @Transactional
     public InvitationDto.Response createInvitation(InvitationDto.CreateRequest request, Long creatorId) {
         // 사용자 조회
@@ -102,6 +102,7 @@ public class InvitationService {
         // 초대장 유효성 검사
         if (!invitation.isValid()) {
             if (LocalDateTime.now().isAfter(invitation.getExpiresAt())) {
+                invitation.expire(); // 상태를 EXPIRED로 변경
                 throw new BaseException(InvitationResponseStatus.INVITATION_EXPIRED);
             } else if (invitation.getUsedCount() >= invitation.getMaxUses()) {
                 throw new BaseException(InvitationResponseStatus.INVITATION_FULLY_USED);

--- a/src/main/java/org/glue/glue_be/meeting/controller/MeetingController.java
+++ b/src/main/java/org/glue/glue_be/meeting/controller/MeetingController.java
@@ -1,4 +1,58 @@
 package org.glue.glue_be.meeting.controller;
 
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.common.response.BaseResponse;
+import org.glue.glue_be.meeting.dto.MeetingDto;
+import org.glue.glue_be.meeting.service.MeetingService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/meetings")
 public class MeetingController {
+
+    private final MeetingService meetingService;
+
+    /**
+     * 모임 생성 API
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public BaseResponse<MeetingDto.CreateResponse> createMeeting(@Valid @RequestBody MeetingDto.CreateRequest request) {
+        Long currentUserId = getCurrentUserId();
+        return new BaseResponse<>(meetingService.createMeeting(request, currentUserId));
+    }
+
+    /**
+     * 모임 참여 API
+     */
+    @GetMapping("/{meetingId}/join")
+    public BaseResponse<Void> joinMeeting(@PathVariable Long meetingId) {
+        Long currentUserId = getCurrentUserId();
+        meetingService.joinMeeting(meetingId, currentUserId);
+        return new BaseResponse<>();
+    }
+
+    /**
+     * 모임 상세 조회 API
+     */
+    @GetMapping("/{meetingId}")
+    public BaseResponse<MeetingDto.Response> getMeeting(@PathVariable Long meetingId) {
+        return new BaseResponse<>(meetingService.getMeeting(meetingId));
+    }
+
+    /**
+     * 현재 로그인한 사용자 ID 가져오기
+     */
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new IllegalStateException("인증 정보를 찾을 수 없습니다.");
+        }
+        return Long.parseLong(authentication.getPrincipal().toString());
+    }
 }

--- a/src/main/java/org/glue/glue_be/meeting/dto/MeetingDto.java
+++ b/src/main/java/org/glue/glue_be/meeting/dto/MeetingDto.java
@@ -1,4 +1,103 @@
 package org.glue.glue_be.meeting.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.glue.glue_be.meeting.entity.Meeting;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class MeetingDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateRequest {
+        @NotBlank(message = "모임 제목은 필수입니다")
+        private String meetingTitle;
+
+        @NotNull(message = "모임 시간은 필수입니다")
+        private LocalDateTime meetingTime;
+
+        @NotBlank(message = "모임 장소는 필수입니다")
+        private String meetingPlaceName;
+
+        private Double meetingPlaceLatitude;
+        private Double meetingPlaceLongitude;
+
+        @NotNull(message = "최소 인원은 필수입니다")
+        @Min(value = 1, message = "최소 인원은 1명 이상이어야 합니다")
+        private Integer minPpl;
+
+        @NotNull(message = "최대 인원은 필수입니다")
+        @Max(value = 100, message = "최대 인원은 100명을 초과할 수 없습니다")
+        private Integer maxPpl;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response {
+        private Long meetingId;
+        private String meetingTitle;
+        private LocalDateTime meetingTime;
+        private String meetingPlaceName;
+        private Double meetingPlaceLatitude;
+        private Double meetingPlaceLongitude;
+        private Integer currentParticipants;
+        private Integer minParticipants;
+        private Integer maxParticipants;
+        private Integer status;
+        private List<Long> participantIds;
+        private Long hostId;
+
+        public static Response from(Meeting meeting) {
+            return Response.builder()
+                    .meetingId(meeting.getMeetingId())
+                    .meetingTitle(meeting.getMeetingTitle())
+                    .meetingTime(meeting.getMeetingTime())
+                    .meetingPlaceName(meeting.getMeetingPlaceName())
+                    .meetingPlaceLatitude(meeting.getMeetingPlaceLatitude())
+                    .meetingPlaceLongitude(meeting.getMeetingPlaceLongitude())
+                    .currentParticipants(meeting.getCurrentParticipants())
+                    .minParticipants(meeting.getMinParticipants())
+                    .maxParticipants(meeting.getMaxParticipants())
+                    .status(meeting.getStatus())
+                    .hostId(meeting.getHost().getUserId())
+                    .participantIds(meeting.getParticipants().stream()
+                            .map(participant -> participant.getUser().getUserId())
+                            .collect(Collectors.toList()))
+                    .build();
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateResponse {
+        private Long meetingId;
+    }
+    
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InvitationRequest {
+        @NotNull(message = "초대할 사용자 ID는 필수입니다")
+        private Long inviteeId;
+    }
 }

--- a/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
@@ -116,6 +116,14 @@ public class Meeting extends BaseEntity {
         this.status = newStatus;
     }
 
+    /**
+     * 미팅을 활성화 상태로 변경합니다.
+     * 상태 코드 1은 활성화 상태를 의미합니다.
+     */
+    public void activateMeeting() {
+        this.status = 1; // 1: 활성화 상태
+    }
+
     public void addParticipant(Participant participant) {
         this.participants.add(participant);
         participant.updateMeeting(this);

--- a/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import org.glue.glue_be.common.BaseEntity;
 import org.glue.glue_be.common.config.LocalDateTimeStringConverter;
+import org.glue.glue_be.user.entity.User;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -30,6 +31,10 @@ public class Meeting extends BaseEntity {
 
     @OneToMany(mappedBy = "meeting")
     private List<Participant> participants = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id", nullable = false)
+    private User host;
 
     @Column(name = "meeting_time", nullable = false)
     @Convert(converter = LocalDateTimeStringConverter.class)
@@ -65,7 +70,8 @@ public class Meeting extends BaseEntity {
                     Integer status,
                     Double meetingPlaceLatitude,
                     Double meetingPlaceLongitude,
-                    String meetingPlaceName) {
+                    String meetingPlaceName,
+                    User host) {
         this.meetingTitle = meetingTitle;
         this.meetingTime = meetingTime;
         this.currentParticipants = currentParticipants;
@@ -75,6 +81,7 @@ public class Meeting extends BaseEntity {
         this.meetingPlaceLatitude = meetingPlaceLatitude;
         this.meetingPlaceLongitude = meetingPlaceLongitude;
         this.meetingPlaceName = meetingPlaceName;
+        this.host = host;
         this.participants = new ArrayList<>();
     }
 
@@ -116,5 +123,9 @@ public class Meeting extends BaseEntity {
 
     public boolean isMeetingFull() {
         return this.participants.size() >= this.maxParticipants;
+    }
+    
+    public boolean isHost(Long userId) {
+        return this.host.getUserId().equals(userId);
     }
 }

--- a/src/main/java/org/glue/glue_be/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/glue/glue_be/meeting/repository/MeetingRepository.java
@@ -1,4 +1,9 @@
 package org.glue.glue_be.meeting.repository;
 
-public class MeetingRepository {
+import org.glue.glue_be.meeting.entity.Meeting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 }

--- a/src/main/java/org/glue/glue_be/meeting/repository/ParticipantRepository.java
+++ b/src/main/java/org/glue/glue_be/meeting/repository/ParticipantRepository.java
@@ -1,0 +1,15 @@
+package org.glue.glue_be.meeting.repository;
+
+import org.glue.glue_be.meeting.entity.Meeting;
+import org.glue.glue_be.meeting.entity.Participant;
+import org.glue.glue_be.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+    Optional<Participant> findByUserAndMeeting(User user, Meeting meeting);
+    boolean existsByUserAndMeeting(User user, Meeting meeting);
+} 

--- a/src/main/java/org/glue/glue_be/meeting/response/MeetingResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/meeting/response/MeetingResponseStatus.java
@@ -19,7 +19,8 @@ public enum MeetingResponseStatus implements ResponseStatus {
     INVALID_MEETING_TIME(HttpStatus.BAD_REQUEST, false, 554, "모임 시간은 현재 시간 이후여야 합니다"),
     ALREADY_JOINED(HttpStatus.BAD_REQUEST, false, 555, "이미 모임에 참여 중입니다"),
     NON_PARTICIPANT_INVITATION(HttpStatus.FORBIDDEN, false, 556, "모임 참가자만 초대장을 생성할 수 있습니다"),
-    NOT_HOST_PERMISSION(HttpStatus.FORBIDDEN, false, 557, "모임 주최자만 이 작업을 수행할 수 있습니다");
+    NOT_HOST_PERMISSION(HttpStatus.FORBIDDEN, false, 557, "모임 주최자만 이 작업을 수행할 수 있습니다"),
+    NOT_JOINED(HttpStatus.FORBIDDEN, false, 558, "모임에 참여하지 않은 사용자입니다");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/meeting/response/MeetingResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/meeting/response/MeetingResponseStatus.java
@@ -1,0 +1,28 @@
+package org.glue.glue_be.meeting.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.glue.glue_be.common.response.ResponseStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum MeetingResponseStatus implements ResponseStatus {
+    
+    /**
+     * 모임 관련 에러
+     */
+    MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, false, 551, "존재하지 않는 모임입니다"),
+    MEETING_FULL(HttpStatus.BAD_REQUEST, false, 552, "모임이 꽉 찼습니다"),
+    MIN_OVER_MAX(HttpStatus.BAD_REQUEST, false, 553, "최소 인원이 최대 인원보다 클 수 없습니다"),
+    INVALID_MEETING_TIME(HttpStatus.BAD_REQUEST, false, 554, "모임 시간은 현재 시간 이후여야 합니다"),
+    ALREADY_JOINED(HttpStatus.BAD_REQUEST, false, 555, "이미 모임에 참여 중입니다"),
+    NON_PARTICIPANT_INVITATION(HttpStatus.FORBIDDEN, false, 556, "모임 참가자만 초대장을 생성할 수 있습니다"),
+    NOT_HOST_PERMISSION(HttpStatus.FORBIDDEN, false, 557, "모임 주최자만 이 작업을 수행할 수 있습니다");
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+} 

--- a/src/main/java/org/glue/glue_be/meeting/service/MeetingService.java
+++ b/src/main/java/org/glue/glue_be/meeting/service/MeetingService.java
@@ -1,4 +1,157 @@
 package org.glue.glue_be.meeting.service;
 
+import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.common.exception.BaseException;
+import org.glue.glue_be.common.response.BaseResponseStatus;
+import org.glue.glue_be.invitation.dto.InvitationDto;
+import org.glue.glue_be.invitation.response.InvitationResponseStatus;
+import org.glue.glue_be.invitation.service.InvitationService;
+import org.glue.glue_be.meeting.dto.MeetingDto;
+import org.glue.glue_be.meeting.entity.Meeting;
+import org.glue.glue_be.meeting.entity.Participant;
+import org.glue.glue_be.meeting.repository.MeetingRepository;
+import org.glue.glue_be.meeting.repository.ParticipantRepository;
+import org.glue.glue_be.meeting.response.MeetingResponseStatus;
+import org.glue.glue_be.user.entity.User;
+import org.glue.glue_be.user.repository.UserRepository;
+import org.glue.glue_be.user.response.UserResponseStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
 public class MeetingService {
+
+    private final MeetingRepository meetingRepository;
+    private final UserRepository userRepository;
+    private final ParticipantRepository participantRepository;
+    private final InvitationService invitationService;
+
+    /**
+     * 모임 생성
+     */
+    @Transactional
+    public MeetingDto.CreateResponse createMeeting(MeetingDto.CreateRequest request, Long creatorId) {
+        // 유효성 검증
+        if (request.getMinPpl() > request.getMaxPpl()) {
+            throw new BaseException(MeetingResponseStatus.MIN_OVER_MAX);
+        }
+
+        if (request.getMeetingTime().isBefore(LocalDateTime.now())) {
+            throw new BaseException(MeetingResponseStatus.INVALID_MEETING_TIME);
+        }
+
+        // 사용자 조회
+        User creator = userRepository.findById(creatorId)
+                .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
+
+        // 모임 생성
+        Meeting meeting = Meeting.builder()
+                .meetingTitle(request.getMeetingTitle())
+                .meetingTime(request.getMeetingTime())
+                .meetingPlaceName(request.getMeetingPlaceName())
+                .meetingPlaceLatitude(request.getMeetingPlaceLatitude())
+                .meetingPlaceLongitude(request.getMeetingPlaceLongitude())
+                .minParticipants(request.getMinPpl())
+                .maxParticipants(request.getMaxPpl())
+                .currentParticipants(1) // 생성자가 첫 번째 참가자
+                .status(1) // 1: 활성화 상태
+                .host(creator) // 호스트 설정
+                .build();
+
+        Meeting savedMeeting = meetingRepository.save(meeting);
+
+        // 생성자를 참가자로 추가
+        Participant participant = Participant.builder()
+                .user(creator)
+                .meeting(savedMeeting)
+                .build();
+        
+        participantRepository.save(participant);
+        savedMeeting.addParticipant(participant);
+
+        return MeetingDto.CreateResponse.builder()
+                .meetingId(savedMeeting.getMeetingId())
+                .build();
+    }
+
+    /**
+     * 모임 초대장 생성
+     */
+    @Transactional
+    public InvitationDto.Response createMeetingInvitation(Long meetingId, Long inviteeId, Long creatorId) {
+        // 모임 존재 확인
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new BaseException(MeetingResponseStatus.MEETING_NOT_FOUND));
+
+        // 초대할 사용자 존재 확인
+        User invitee = userRepository.findById(inviteeId)
+                .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
+
+        // 초대 생성자가 모임의 호스트인지 확인
+        if (!meeting.isHost(creatorId)) {
+            throw new BaseException(MeetingResponseStatus.NOT_HOST_PERMISSION);
+        }
+
+        // 이미 참가자인지 확인
+        if (participantRepository.existsByUserAndMeeting(invitee, meeting)) {
+            throw new BaseException(InvitationResponseStatus.INVITATION_ALREADY_JOINED);
+        }
+
+        // 초대장 생성
+        InvitationDto.CreateRequest invitationRequest = new InvitationDto.CreateRequest();
+        invitationRequest.setMeetingId(meetingId);
+        invitationRequest.setMaxUses(1); // 1회용 초대장
+        invitationRequest.setExpirationDays(0); // 6시간 후 만료 (0.25일)
+        invitationRequest.setExpirationHours(6); // 6시간
+        invitationRequest.setInviteeId(inviteeId); // 초대된 사용자 ID 설정
+
+        return invitationService.createInvitation(invitationRequest, creatorId);
+    }
+
+    /**
+     * 모임 참여
+     */
+    @Transactional
+    public void joinMeeting(Long meetingId, Long userId) {
+        // 모임 존재 확인
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new BaseException(MeetingResponseStatus.MEETING_NOT_FOUND));
+
+        // 사용자 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
+
+        // 이미 참가자인지 확인
+        if (participantRepository.existsByUserAndMeeting(user, meeting)) {
+            throw new BaseException(MeetingResponseStatus.ALREADY_JOINED);
+        }
+
+        // 모임이 꽉 찼는지 확인
+        if (meeting.isMeetingFull()) {
+            throw new BaseException(MeetingResponseStatus.MEETING_FULL);
+        }
+
+        // 참가자 추가
+        Participant participant = Participant.builder()
+                .user(user)
+                .meeting(meeting)
+                .build();
+
+        participantRepository.save(participant);
+        meeting.addParticipant(participant);
+    }
+
+    /**
+     * 모임 조회
+     */
+    @Transactional(readOnly = true)
+    public MeetingDto.Response getMeeting(Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new BaseException(MeetingResponseStatus.MEETING_NOT_FOUND));
+        
+        return MeetingDto.Response.from(meeting);
+    }
 }

--- a/src/main/java/org/glue/glue_be/user/response/UserResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/user/response/UserResponseStatus.java
@@ -1,0 +1,22 @@
+package org.glue.glue_be.user.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.glue.glue_be.common.response.ResponseStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum UserResponseStatus implements ResponseStatus {
+    
+    /**
+     * 사용자 관련 에러
+     */
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 501, "존재하지 않는 사용자입니다");
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+} 


### PR DESCRIPTION
## 변경사항 요약

1. **공통 예외/응답 구조 리팩토링**  
   - `BaseResponseStatus`가 `ResponseStatus` 인터페이스를 구현하도록 변경  
     → 이제 `InvitationResponseStatus`, `MeetingResponseStatus`, `UserResponseStatus` 등 다양한 에러 상태를 한 인터페이스(`ResponseStatus`)로 관리  
   - `BaseException`과 `BaseResponse`가 `ResponseStatus`를 활용하도록 수정  
     - `BaseException`: `BaseResponseStatus` 대신 `ResponseStatus` 타입을 받고, `detailMessage`로 구체적 오류 메시지 관리  
     - `BaseResponse`: 실패 응답 시 `ResponseStatus`를 받아서 HTTP 상태 코드, 메시지, 코드 등을 일관성 있게 설정

2. **초대장(Invitation) 기능 추가**  
   - **InvitationController**, **InvitationService**, **Invitation** 엔티티, **InvitationRepository** 구현  
     - **생성 API**: 특정 모임(meetingId)에 초대장을 생성하고, 유효기간(`expiresAt`), 최대 사용 횟수(`maxUses`), 초대 대상(`inviteeId`) 등을 지정  
     - **수락 API**: 초대장 코드로 모임에 참여  
       - 비관적 락(pessimistic lock) 사용으로 동시에 같은 초대장을 사용할 때 충돌 방지  
       - 초대장 유효성 검사 (만료, 최대 사용 횟수 초과, 특정 사용자 초대장 등)  
     - **목록 조회 API**: 자신이 만든 초대장 목록을 페이징 조회
   - **InvitationResponseStatus**: 초대장 전용 예외 코드를 정의 (예: `INVITATION_NOT_FOUND`, `INVITATION_EXPIRED` 등)

3. **모임(Meeting) 관련 기능 추가/수정**  
   - **MeetingController**, **MeetingService**, **Meeting** 엔티티, **MeetingRepository**, **ParticipantRepository** 구현  
     - **모임 생성 API**: 제목/장소/시간/최대·최소 인원 등 입력으로 새 모임 생성  
       - 모임 호스트(creator) 지정, 호스트를 자동으로 첫 참가자로 등록  
       - 모임 시간 검증(현재 시각 이후), 최소/최대 인원 검증  
     - **모임 참여 API**: `{meetingId}/join` 경로로 참여  
       - 모임이 꽉 찼는지(`isMeetingFull`), 이미 참여 중인지(`existsByUserAndMeeting`) 검사  
     - **모임 상세 조회 API**: 참여자 목록(참여자 ID들), 호스트 ID, 위치 정보 등 반환
   - **MeetingResponseStatus**: 모임 전용 예외 코드 정의 (예: `MEETING_NOT_FOUND`, `MEETING_FULL`, `MIN_OVER_MAX` 등)

4. **사용자(User) 관련 예외처리**  
   - **UserResponseStatus** 추가: `USER_NOT_FOUND`  
   - 서비스 로직(`InvitationService`, `MeetingService`)에서 사용자 조회 시 없으면 예외 발생

---

## 주요 파일별 변경 내용

- **BaseException, BaseResponse, BaseResponseStatus**  
  - `ResponseStatus` 인터페이스 도입 및 리팩토링
  - 에러 코드/메시지/성공여부를 enum에서 일관성 있게 가져옴
- **InvitationController & InvitationService**  
  - 초대장 생성/수락/목록 조회 API 구현
  - 초대장 엔티티(`Invitation`)의 만료시간, 최대 사용 횟수, 특정 사용자 초대 여부 등을 관리
- **MeetingController & MeetingService**  
  - 모임 생성, 참여, 상세 조회 API 구현
  - 모임 엔티티(`Meeting`)에 호스트 정보(`User host`) 추가
  - 참조 엔티티(Participant) 통해 다대다 관계 구축
- **ResponseStatus 구현체**  
  - `InvitationResponseStatus`, `MeetingResponseStatus`, `UserResponseStatus` → 각 도메인별 에러 정의  
- **User 조회 예외 처리**  
  - `UserRepository`에서 `findById()` 실패 시 `USER_NOT_FOUND` 예외 발생

---

## 추가 참고 사항
- 초대장 코드는 `UUID` 8자리로 생성
- 초대장 유효성(만료, 최대 사용 횟수, 특정 사용자 등) 체크 로직은 **InvitationService.acceptInvitation**에서 수행
- 모임 기능의 경우 호스트만 초대장을 생성할 수 있도록 권한 검사(`NOT_HOST_PERMISSION`) 추가
---
