### PR TITLE
feat: 애플 기반 로그인/회원가입 기능 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ out/
 
 ### application property ###
 *.yml
+!/src/main/resources/key/

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,12 @@ dependencies {
 	implementation 'org.xerial:sqlite-jdbc:3.41.2.2' // sqlite jdbc
     implementation 'org.hibernate.orm:hibernate-community-dialects' // sqlite3 dialect
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+	implementation 'com.nimbusds:nimbus-jose-jwt:9.37.2'
+	implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+	implementation 'com.auth0:java-jwt:3.18.2'
+	implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
+	implementation 'commons-io:commons-io:2.14.0'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/glue/glue_be/common/config/AppleProperties.java
+++ b/src/main/java/org/glue/glue_be/common/config/AppleProperties.java
@@ -1,0 +1,35 @@
+package org.glue.glue_be.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "apple")
+public class AppleProperties {
+
+    private Auth auth = new Auth();
+    private String redirectUri; // TODO: 현재 미사용 => 추후 상황보고 삭제
+    private String iss;
+    private String aud;
+    private String teamId;
+    private String grantType;
+    private Key key = new Key();
+
+    @Getter
+    @Setter
+    public static class Auth {
+        private String tokenUrl;
+        private String publicKeyUrl;
+    }
+
+    @Getter
+    @Setter
+    public static class Key {
+        private String id;
+        private String path;
+    }
+}

--- a/src/main/java/org/glue/glue_be/common/config/SocialConfig.java
+++ b/src/main/java/org/glue/glue_be/common/config/SocialConfig.java
@@ -1,13 +1,16 @@
 package org.glue.glue_be.common.config;
 
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.context.annotation.*;
+import org.springframework.http.*;
+import org.springframework.web.reactive.function.client.WebClient;
 
-@Component
+@Configuration
 public class SocialConfig {
-    private final RestTemplate restTemplate = new RestTemplate();
-
-    public RestTemplate restTemplate() {
-        return restTemplate;
+    @Bean
+    public WebClient appleWebClient(WebClient.Builder builder, AppleProperties appleProperties) {
+        return builder
+                .baseUrl(appleProperties.getAuth().getTokenUrl())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .build();
     }
 }

--- a/src/main/java/org/glue/glue_be/common/config/SocialConfig.java
+++ b/src/main/java/org/glue/glue_be/common/config/SocialConfig.java
@@ -1,0 +1,13 @@
+package org.glue.glue_be.common.config;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class SocialConfig {
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public RestTemplate restTemplate() {
+        return restTemplate;
+    }
+}

--- a/src/main/java/org/glue/glue_be/user/controller/AppleLoginController.java
+++ b/src/main/java/org/glue/glue_be/user/controller/AppleLoginController.java
@@ -1,0 +1,35 @@
+package org.glue.glue_be.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.glue.glue_be.common.response.BaseResponse;
+import org.glue.glue_be.user.dto.request.AppleSignInRequestDto;
+import org.glue.glue_be.user.dto.request.AppleSignUpRequestDto;
+import org.glue.glue_be.user.dto.response.AppleSignInResponseDto;
+import org.glue.glue_be.user.dto.response.AppleSignUpResponseDto;
+import org.glue.glue_be.user.service.AuthService;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/apple")
+public class AppleLoginController {
+
+    private final AuthService authService;
+
+
+    @PostMapping("/signup")
+    public BaseResponse<AppleSignUpResponseDto> appleSignUp(@Valid @RequestBody AppleSignUpRequestDto requestDto) {
+        AppleSignUpResponseDto responseDto = authService.appleSignUp(requestDto);
+        return new BaseResponse<>(responseDto);
+    }
+
+    @PostMapping("/signin")
+    public BaseResponse<AppleSignInResponseDto> appleSignIn(@Valid @RequestBody AppleSignInRequestDto requestDto) {
+        AppleSignInResponseDto responseDto = authService.appleSignIn(requestDto);
+        return new BaseResponse<>(responseDto);
+    }
+
+}

--- a/src/main/java/org/glue/glue_be/user/dto/request/AppleSignInRequestDto.java
+++ b/src/main/java/org/glue/glue_be/user/dto/request/AppleSignInRequestDto.java
@@ -1,0 +1,8 @@
+package org.glue.glue_be.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AppleSignInRequestDto(
+        @NotBlank(message = "Authorization code는 필수 입력값입니다.")
+        String authorizationCode) {
+}

--- a/src/main/java/org/glue/glue_be/user/dto/request/AppleSignUpRequestDto.java
+++ b/src/main/java/org/glue/glue_be/user/dto/request/AppleSignUpRequestDto.java
@@ -20,7 +20,7 @@ public record AppleSignUpRequestDto(
         @Past(message = "생년월일은 과거 날짜여야 합니다.")
         LocalDate birthDate,
 
-        @NotNull(message = "국기는 필수 입력값입니다.")
+        @NotNull(message = "국가는 필수 입력값입니다.")
         Integer nation,
 
         @NotBlank(message = "한마디는 필수 입력값입니다.")

--- a/src/main/java/org/glue/glue_be/user/dto/request/AppleSignUpRequestDto.java
+++ b/src/main/java/org/glue/glue_be/user/dto/request/AppleSignUpRequestDto.java
@@ -1,0 +1,34 @@
+package org.glue.glue_be.user.dto.request;
+
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+
+public record AppleSignUpRequestDto(
+        @NotBlank(message = "Authorization code는 필수 입력값입니다.")
+        String authorizationCode,
+
+        @NotBlank(message = "이름은 필수 입력값입니다.")
+        String userName,
+
+        @NotBlank(message = "닉네임은 필수 입력값입니다.")
+        String nickName,
+
+        @NotNull(message = "성별은 필수 입력값입니다.")
+        Integer gender,
+
+        @NotNull(message = "생년월일은 필수 입력값입니다.")
+        @Past(message = "생년월일은 과거 날짜여야 합니다.")
+        LocalDate birthDate,
+
+        @NotNull(message = "국기는 필수 입력값입니다.")
+        Integer nation,
+
+        @NotBlank(message = "한마디는 필수 입력값입니다.")
+        String description,
+
+        @NotNull(message = "전공은 필수 입력값입니다.")
+        Integer major,
+
+        @NotNull(message = "전공 노출 여부는 필수 입력값입니다.")
+        Integer majorVisibility
+) {}

--- a/src/main/java/org/glue/glue_be/user/dto/request/KakaoSignUpRequestDto.java
+++ b/src/main/java/org/glue/glue_be/user/dto/request/KakaoSignUpRequestDto.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Getter
 public class KakaoSignUpRequestDto {
 
-	private Long oauthId;
+	private String oauthId;
 
 	private String userName;
 

--- a/src/main/java/org/glue/glue_be/user/dto/response/AppleSignInResponseDto.java
+++ b/src/main/java/org/glue/glue_be/user/dto/response/AppleSignInResponseDto.java
@@ -1,0 +1,11 @@
+package org.glue.glue_be.user.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+public class AppleSignInResponseDto {
+
+    private String accessToken;
+
+}

--- a/src/main/java/org/glue/glue_be/user/dto/response/AppleSignUpResponseDto.java
+++ b/src/main/java/org/glue/glue_be/user/dto/response/AppleSignUpResponseDto.java
@@ -1,0 +1,11 @@
+package org.glue.glue_be.user.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+public class AppleSignUpResponseDto {
+
+    private String accessToken;
+
+}

--- a/src/main/java/org/glue/glue_be/user/dto/response/AppleSocialTokenInfoResponseDto.java
+++ b/src/main/java/org/glue/glue_be/user/dto/response/AppleSocialTokenInfoResponseDto.java
@@ -1,0 +1,11 @@
+package org.glue.glue_be.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AppleSocialTokenInfoResponseDto(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("token_type")   String tokenType,
+        @JsonProperty("expires_in")   Long   expiresIn,
+        @JsonProperty("refresh_token")String refreshToken,
+        @JsonProperty("id_token")     String idToken
+) {}

--- a/src/main/java/org/glue/glue_be/user/dto/response/AppleUserInfoResponseDto.java
+++ b/src/main/java/org/glue/glue_be/user/dto/response/AppleUserInfoResponseDto.java
@@ -1,0 +1,2 @@
+package org.glue.glue_be.user.dto.response;public class AppleUserInfoResponseDtp {
+}

--- a/src/main/java/org/glue/glue_be/user/dto/response/AppleUserInfoResponseDto.java
+++ b/src/main/java/org/glue/glue_be/user/dto/response/AppleUserInfoResponseDto.java
@@ -1,2 +1,17 @@
-package org.glue.glue_be.user.dto.response;public class AppleUserInfoResponseDtp {
+package org.glue.glue_be.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor
+@Data
+public class AppleUserInfoResponseDto {
+    // 고유ID
+    @JsonProperty("sub")
+    private String subject;
+
+    @JsonProperty("email")
+    private String email;
 }

--- a/src/main/java/org/glue/glue_be/user/dto/response/KakaoUserInfoResponseDto.java
+++ b/src/main/java/org/glue/glue_be/user/dto/response/KakaoUserInfoResponseDto.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoUserInfoResponseDto(
-	Long id,
+	String id,
 	KakaoAccount kakaoAccount
 ) {
 

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -23,7 +23,7 @@ public class User extends BaseEntity {
     private UUID uuid;
 
     @Column(name = "oauth_id", nullable = false, unique = true)
-    private Long oauthId;
+    private String oauthId;
 
     @Column(name = "user_name", nullable = false, length = 20)
     private String userName;
@@ -59,7 +59,7 @@ public class User extends BaseEntity {
 
 
     @Builder
-    public User(UUID uuid, Long oauthId, String userName, String nickname, Integer gender, LocalDate birth,
+    public User(UUID uuid, String oauthId, String userName, String nickname, Integer gender, LocalDate birth,
                 Integer nation, String description, Integer certified, Integer major, Integer majorVisibility) {
         this.uuid = uuid;
         this.oauthId = oauthId;

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -23,7 +23,7 @@ public class User extends BaseEntity {
     private UUID uuid;
 
     @Column(name = "oauth_id", nullable = false, unique = true)
-    private Long oauthId;
+    private String oauthId;
 
     @Column(name = "user_name", nullable = false, length = 20)
     private String userName;
@@ -56,7 +56,7 @@ public class User extends BaseEntity {
 
 
     @Builder
-    public User(UUID uuid, Long oauthId, String userName, String nickname, Integer gender, LocalDate birth,
+    public User(UUID uuid, String oauthId, String userName, String nickname, Integer gender, LocalDate birth,
                 Integer nation, String description, Integer certified, Integer major, Integer majorVisibility) {
         this.uuid = uuid;
         this.oauthId = oauthId;

--- a/src/main/java/org/glue/glue_be/user/repository/UserRepository.java
+++ b/src/main/java/org/glue/glue_be/user/repository/UserRepository.java
@@ -12,6 +12,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	//1. oauthID로 유저찾기
-	Optional<User> findByOauthId(Long oauthId);
+	Optional<User> findByOauthId(String oauthId);
 
 }

--- a/src/main/java/org/glue/glue_be/user/service/AppleService.java
+++ b/src/main/java/org/glue/glue_be/user/service/AppleService.java
@@ -86,7 +86,7 @@ public class AppleService {
         return response.getBody();
     }
 
-    public void verifyIdentityToken(String idToken) {
+    private void verifyIdentityToken(String idToken) {
         SignedJWT signedJWT = parseToken(idToken);
         JWTClaimsSet claims = extractClaims(signedJWT);
 

--- a/src/main/java/org/glue/glue_be/user/service/AppleService.java
+++ b/src/main/java/org/glue/glue_be/user/service/AppleService.java
@@ -1,0 +1,217 @@
+package org.glue.glue_be.user.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.*;
+
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.crypto.*;
+import com.nimbusds.jose.jwk.*;
+import com.nimbusds.jwt.*;
+
+import io.jsonwebtoken.*;
+
+import java.io.*;
+import java.net.*;
+import java.nio.charset.*;
+import java.security.*;
+import java.security.interfaces.RSAPublicKey;
+import java.text.*;
+import java.time.*;
+import java.util.*;
+
+import org.apache.commons.io.*;
+
+import org.bouncycastle.asn1.pkcs.*;
+import org.bouncycastle.openssl.jcajce.*;
+
+import org.glue.glue_be.common.config.*;
+import org.glue.glue_be.common.exception.*;
+import org.glue.glue_be.common.response.*;
+import org.glue.glue_be.user.dto.response.*;
+
+import lombok.extern.slf4j.*;
+
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.core.io.*;
+import org.springframework.http.*;
+import org.springframework.stereotype.*;
+
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+
+
+@Slf4j
+@Service
+public class AppleService {
+
+//    private static final String NONCE = "20B20D-0S8-1K8"; // TODO: 프론트 쪽과 협의 필요 (지금은 임시 값)
+
+    private final AppleProperties appleProperties;
+    private final SocialConfig socialConfig;
+
+    @Autowired
+    public AppleService(AppleProperties appleProperties, SocialConfig socialConfig) {
+        this.appleProperties = appleProperties;
+        this.socialConfig = socialConfig;
+    }
+
+
+    public AppleUserInfoResponseDto getAppleUserProfile(String authorizationCode) {
+        // 1) Apple 서버에서 토큰 교환
+        AppleSocialTokenInfoResponseDto tokenInfo = requestToken(authorizationCode);
+
+        // 2) 토큰 검증
+        verifyIdentityToken(tokenInfo.idToken());
+
+        // 3) ID 토큰에서 사용자 정보 추출
+        return parseUserInfo(tokenInfo.idToken());
+    }
+
+    private AppleSocialTokenInfoResponseDto requestToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.valueOf(APPLICATION_FORM_URLENCODED_VALUE));
+
+        String requestBody = "client_id=" + appleProperties.getAud()
+                + "&client_secret=" + generateClientSecret()
+                + "&grant_type=" + appleProperties.getGrantType()
+                + "&code=" + code;
+
+        HttpEntity<String> request = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<AppleSocialTokenInfoResponseDto> response = socialConfig.restTemplate().exchange(
+                appleProperties.getAuth().getTokenUrl(),
+                HttpMethod.POST,
+                request,
+                AppleSocialTokenInfoResponseDto.class);
+
+        return response.getBody();
+    }
+
+    public void verifyIdentityToken(String idToken) {
+        SignedJWT signedJWT = parseToken(idToken);
+        JWTClaimsSet claims = extractClaims(signedJWT);
+
+        verifyExpiration(claims.getExpirationTime());
+//        verifyNonce(claims.getStringClaim("nonce"));
+        verifyIssuer(claims.getIssuer());
+        verifyAudience(claims.getAudience());
+        verifySignature(signedJWT);
+    }
+
+    private AppleUserInfoResponseDto parseUserInfo(String idToken) {
+        DecodedJWT jwt = JWT.decode(idToken);
+        return AppleUserInfoResponseDto.builder()
+                .subject(jwt.getClaim("sub").asString())
+                .email(jwt.getClaim("email").asString())
+                .build();
+    }
+
+
+    private String generateClientSecret() {
+        LocalDateTime expiration = LocalDateTime.now().plusMinutes(5);
+        return Jwts.builder()
+                .setHeaderParam(JwsHeader.KEY_ID, appleProperties.getKey().getId())
+                .setIssuer(appleProperties.getTeamId())
+                .setAudience(appleProperties.getIss())
+                .setSubject(appleProperties.getAud())
+                .setExpiration(Date.from(expiration.atZone(ZoneId.systemDefault()).toInstant()))
+                .setIssuedAt(new Date())
+                .signWith(getPrivateKey(), SignatureAlgorithm.ES256)
+                .compact();
+    }
+
+    // PrivateKey를 PEM 파일에서 읽어와 변환하여 반환
+    private PrivateKey getPrivateKey() {
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+
+        try {
+            ClassPathResource resource = new ClassPathResource(appleProperties.getKey().getPath());
+            try (InputStream is = resource.getInputStream()) {
+                String keyContent = IOUtils.toString(is, StandardCharsets.UTF_8);
+                keyContent = keyContent.replaceAll("-----BEGIN (.*)-----", "")
+                        .replaceAll("-----END (.*)-----", "")
+                        .replaceAll("\\s", "");
+                byte[] privateKeyBytes = Base64.getDecoder().decode(keyContent);
+                PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(privateKeyBytes);
+                return converter.getPrivateKey(privateKeyInfo);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("PrivateKey 변환 실패", e);
+        }
+    }
+
+    private SignedJWT parseToken(String idToken) {
+        try {
+            return SignedJWT.parse(idToken);
+        } catch (ParseException e) {
+            throw new BaseException(BaseResponseStatus.WRONG_JWT_TOKEN,
+                    "토큰 디코딩 실패: " + idToken + " - " + e.getMessage());
+        }
+    }
+
+
+    private JWTClaimsSet extractClaims(SignedJWT signedJWT) {
+        try {
+            return signedJWT.getJWTClaimsSet();
+        } catch (ParseException e) {
+            throw new BaseException(BaseResponseStatus.WRONG_JWT_TOKEN,
+                    "토큰 클레임 추출 실패: " + e.getMessage());
+        }
+    }
+
+
+    private void verifyExpiration(Date expirationTime) {
+        Date currentTime = new Date();
+        if (expirationTime == null || expirationTime.before(currentTime)) {
+            throw new BaseException(BaseResponseStatus.WRONG_JWT_TOKEN,
+                    "토큰 만료됨: 만료 시간은 " + expirationTime + "입니다.");
+        }
+    }
+
+    // TODO: 프론트 쪽과 협의 필요
+//    private void verifyNonce(String nonce) {
+//        if (nonce == null || !NONCE.equals(nonce)) {
+//            throw new BaseException(BaseResponseStatus.WRONG_JWT_TOKEN,
+//                    "Nonce 불일치: 기대값 " + NONCE + ", 실제 " + nonce);
+//        }
+//    }
+
+
+    private void verifyIssuer(String issuer) {
+        if (!appleProperties.getIss().equals(issuer)) {
+            throw new BaseException(BaseResponseStatus.WRONG_JWT_TOKEN,
+                    "Issuer 불일치: 기대값 " + appleProperties.getIss() + ", 실제 " + issuer);
+        }
+    }
+
+
+    private void verifyAudience(List<String> audience) {
+        if (audience == null || audience.isEmpty() || !appleProperties.getAud().equals(audience.get(0))) {
+            String actual = (audience != null && !audience.isEmpty()) ? audience.get(0) : "null";
+            throw new BaseException(BaseResponseStatus.WRONG_JWT_TOKEN,
+                    "Audience 불일치: 기대값 " + appleProperties.getAud() + ", 실제 " + actual);
+        }
+    }
+
+    private void verifySignature(SignedJWT signedJWT) {
+        String keyId = signedJWT.getHeader().getKeyID();
+        try {
+            URL publicKeyUrl = new URL(appleProperties.getAuth().getPublicKeyUrl());
+            JWKSet jwkSet = JWKSet.load(publicKeyUrl);
+            JWK jwk = jwkSet.getKeyByKeyId(keyId);
+
+            if (jwk == null) {
+                throw new BaseException(BaseResponseStatus.WRONG_JWT_TOKEN, "키 아이디를 찾을 수 없음: " + keyId);
+            }
+
+            RSAPublicKey publicKey = ((com.nimbusds.jose.jwk.RSAKey) jwk).toRSAPublicKey();
+            JWSVerifier verifier = new RSASSAVerifier(publicKey);
+            if (!signedJWT.verify(verifier)) {
+                throw new BaseException(BaseResponseStatus.WRONG_JWT_TOKEN, "서명 검증 실패");
+            }
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.WRONG_JWT_TOKEN,
+                    "서명 검증 중 오류 발생: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/glue/glue_be/user/service/AuthService.java
+++ b/src/main/java/org/glue/glue_be/user/service/AuthService.java
@@ -1,27 +1,26 @@
 package org.glue.glue_be.user.service;
 
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.glue.glue_be.common.exception.BaseException;
 import org.glue.glue_be.common.jwt.JwtTokenProvider;
 import org.glue.glue_be.common.jwt.UserAuthentication;
-import org.glue.glue_be.common.response.BaseResponseStatus;
+import org.glue.glue_be.user.dto.request.AppleSignInRequestDto;
+import org.glue.glue_be.user.dto.request.AppleSignUpRequestDto;
 import org.glue.glue_be.user.dto.request.KakaoSignInRequestDto;
 import org.glue.glue_be.user.dto.request.KakaoSignUpRequestDto;
+import org.glue.glue_be.user.dto.response.AppleSignInResponseDto;
+import org.glue.glue_be.user.dto.response.AppleSignUpResponseDto;
+import org.glue.glue_be.user.dto.response.AppleUserInfoResponseDto;
 import org.glue.glue_be.user.dto.response.KakaoSignInResponseDto;
 import org.glue.glue_be.user.dto.response.KakaoSignUpResponseDto;
 import org.glue.glue_be.user.dto.response.KakaoUserInfoResponseDto;
 import org.glue.glue_be.user.entity.User;
 import org.glue.glue_be.user.repository.UserRepository;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.NoSuchElementException;
 import java.util.UUID;
 
 
@@ -31,77 +30,130 @@ import java.util.UUID;
 @Transactional
 public class AuthService {
 
-	// services
-	private final KakaoService kakaoService;
+    // services
+    private final KakaoService kakaoService;
+    private final AppleService appleService;
 
-	// utils
-	private final JwtTokenProvider jwtTokenProvider;
+    // utils
+    private final JwtTokenProvider jwtTokenProvider;
 
-	// repositories
-	private final UserRepository userRepository;
-
-
-	// todo: 추후 리팩토링 시 과정 중 역할의 책임을 나눌만한 부분이 있는지 보기
-	public KakaoSignUpResponseDto kakaoSignUp(KakaoSignUpRequestDto requestDto) {
-
-		// 1. 중복되는 oauthID의 유저가 db에 있는지 재검증
-		userRepository.findByOauthId(requestDto.getOauthId())
-			.ifPresent(user -> {
-				throw new IllegalStateException("해당 OAuth ID의 사용자가 이미 존재합니다.");
-			});
-
-		// 2. 입력받은 정보를 취합해 User 객체 조립
-		User user = User.builder()
-			.uuid(UUID.randomUUID())
-			.oauthId(requestDto.getOauthId())
-			.userName(requestDto.getUserName())
-			.nickname(requestDto.getNickName())
-			.gender(requestDto.getGender())
-			.birth(requestDto.getBirthDate())
-			.nation(requestDto.getNation())
-			.description(requestDto.getDescription())
-			.certified(0)
-			.major(requestDto.getMajor())
-			.majorVisibility(requestDto.getMajorVisibility())
-			.build();
-
-		// 3. DB에 신규 유저 저장
-		User newUser = userRepository.save(user);
-
-		// 4. 자체 엑세스 토큰 발급
-		UserAuthentication userAuthentication = new UserAuthentication(newUser.getUserId(), null, null);
-		String jwtToken = jwtTokenProvider.generateToken(userAuthentication);
-		log.info("[authservice - SignUpAPI] jwtToken => {}", jwtToken);
-
-		//5. dto에 토큰을 담아 리턴
-		return KakaoSignUpResponseDto.builder().accessToken(jwtToken).build();
+    // repositories
+    private final UserRepository userRepository;
 
 
-	}
+    // todo: 추후 리팩토링 시 과정 중 역할의 책임을 나눌만한 부분이 있는지 보기
+    public KakaoSignUpResponseDto kakaoSignUp(KakaoSignUpRequestDto requestDto) {
 
-	public KakaoSignInResponseDto kakaoSignIn(KakaoSignInRequestDto requestDto){
+        // 1. 중복되는 oauthID의 유저가 db에 있는지 재검증
+        userRepository.findByOauthId(requestDto.getOauthId())
+                .ifPresent(user -> {
+                    throw new IllegalStateException("해당 OAuth ID의 사용자가 이미 존재합니다.");
+                });
 
-		// 1. 토큰을 카카오 서버에 보내 유저 정보를 받는다.
-		KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(requestDto.getKakaoToken());
+        // 2. 입력받은 정보를 취합해 User 객체 조립
+        User user = User.builder()
+                .uuid(UUID.randomUUID())
+                .oauthId(requestDto.getOauthId())
+                .userName(requestDto.getUserName())
+                .nickname(requestDto.getNickName())
+                .gender(requestDto.getGender())
+                .birth(requestDto.getBirthDate())
+                .nation(requestDto.getNation())
+                .description(requestDto.getDescription())
+                .certified(0)
+                .major(requestDto.getMajor())
+                .majorVisibility(requestDto.getMajorVisibility())
+                .build();
 
-		// 2. oauthId를 가져와 유저가 있는지 db를 조회한다.
-		Long oauthId = userInfo.id();
+        // 3. DB에 신규 유저 저장
+        User newUser = userRepository.save(user);
 
-		log.info("[authService - signin API] oauthID -> {}", oauthId);
+        // 4. 자체 엑세스 토큰 발급
+        UserAuthentication userAuthentication = new UserAuthentication(newUser.getUserId(), null, null);
+        String jwtToken = jwtTokenProvider.generateToken(userAuthentication);
+        log.info("[authservice - SignUpAPI] jwtToken => {}", jwtToken);
 
-		// 2.5. 유저를 조회하고 없다면 401 예외 발생
-		User user = userRepository.findByOauthId(oauthId).orElseThrow(
-			() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "해당 사용자는 존재하지 않습니다."));
+        //5. dto에 토큰을 담아 리턴
+        return KakaoSignUpResponseDto.builder().accessToken(jwtToken).build();
 
-		// 3. 자체 엑세스 토큰을 발행 후 리턴
-		UserAuthentication userAuthentication = new UserAuthentication(user.getUserId(), null, null);
 
-		String jwtToken = jwtTokenProvider.generateToken(userAuthentication);
+    }
 
-		log.info("[authservice - SignInAPI] jwtToken => {}", jwtToken);
+    public KakaoSignInResponseDto kakaoSignIn(KakaoSignInRequestDto requestDto) {
 
-		return KakaoSignInResponseDto.builder().accessToken(jwtToken).build();
+        // 1. 토큰을 카카오 서버에 보내 유저 정보를 받는다.
+        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(requestDto.getKakaoToken());
 
-	}
+        // 2. oauthId를 가져와 유저가 있는지 db를 조회한다.
+        String oauthId = userInfo.id();
+
+        log.info("[authService - signin API] oauthID -> {}", oauthId);
+
+        // 2.5. 유저를 조회하고 없다면 401 예외 발생
+        User user = userRepository.findByOauthId(oauthId).orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "해당 사용자는 존재하지 않습니다."));
+
+        // 3. 자체 엑세스 토큰을 발행 후 리턴
+        UserAuthentication userAuthentication = new UserAuthentication(user.getUserId(), null, null);
+
+        String jwtToken = jwtTokenProvider.generateToken(userAuthentication);
+
+        log.info("[authservice - SignInAPI] jwtToken => {}", jwtToken);
+
+        return KakaoSignInResponseDto.builder().accessToken(jwtToken).build();
+
+    }
+
+    public AppleSignUpResponseDto appleSignUp(
+            AppleSignUpRequestDto requestDto) {
+
+        AppleUserInfoResponseDto appleUserInfo = appleService.getAppleUserProfile(requestDto.authorizationCode());
+
+        userRepository.findByOauthId(appleUserInfo.getSubject())
+                .ifPresent(user -> {
+                    throw new IllegalStateException("해당 OAuth ID의 사용자가 이미 존재합니다.");
+                });
+
+        User user = User.builder()
+                .uuid(UUID.randomUUID())
+                .oauthId(appleUserInfo.getSubject())
+                .userName(requestDto.userName())
+                .nickname(requestDto.nickName())
+                .gender(requestDto.gender())
+                .birth(requestDto.birthDate())
+                .nation(requestDto.nation())
+                .description(requestDto.description())
+                .certified(0)
+                .major(requestDto.major())
+                .majorVisibility(requestDto.majorVisibility())
+                .build();
+
+        User newUser = userRepository.save(user);
+
+        UserAuthentication authentication = new UserAuthentication(newUser.getUserId(), null, null);
+        String jwtToken = jwtTokenProvider.generateToken(authentication);
+        log.info("[AuthService - AppleSignUp] JWT Token: {}", jwtToken);
+
+        return AppleSignUpResponseDto.builder()
+                .accessToken(jwtToken)
+                .build();
+    }
+
+    public AppleSignInResponseDto appleSignIn(AppleSignInRequestDto requestDto) {
+        AppleUserInfoResponseDto appleUserInfo = appleService.getAppleUserProfile(requestDto.authorizationCode());
+
+        User user = userRepository.findByOauthId(appleUserInfo.getSubject())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED,
+                        "해당 Apple 계정 사용자가 존재하지 않습니다."));
+
+        UserAuthentication authentication = new UserAuthentication(user.getUserId(), null, null);
+
+        String jwtToken = jwtTokenProvider.generateToken(authentication);
+        log.info("[AuthService - AppleSignIn] JWT Token: {}", jwtToken);
+
+        return AppleSignInResponseDto.builder()
+                .accessToken(jwtToken)
+                .build();
+    }
 
 }


### PR DESCRIPTION
## 구현사항
- **Apple OAuth 로그인/회원가입 API**  
  - `POST /api/auth/apple/signup`  
  - `POST /api/auth/apple/signin`  
- **AppleService**  
  - authorization code → 토큰 교환 (`requestToken`)  
  - `SignedJWT` → 파싱·만료·issuer·audience·signature 검증 (`verifyIdentityToken`)  
  - idToken → `sub`, `email` 추출 (`parseUserInfo`)  
  - client secret 생성 (ES256 키 사용)  
- **AuthService**  
  - Apple 유저 정보 조회 → DB 중복 검사 → 신규회원 저장 → 자체 JWT 발급  
  - 로그인 시 존재 여부 확인 후 JWT 발급  
- **설정 및 유틸**  
  - `AppleProperties` (`@ConfigurationProperties(prefix = "apple")`)  
  - `SocialConfig` (`RestTemplate` 빈 등록)  
- **그 외 변경점**  
  - `application.yml`에 Apple 설정 추가 및 `.gitignore` 업데이트  

## 설명할 부분
1. **AppleService**  
   - **_Apple 서버와의 토큰 교환 → 토큰 검증 → 사용자 정보 파싱_** 전 과정을 담당  
   - ES256 알고리즘으로 client secret 생성 로직  

2. **AuthService**  
   - Apple 회원가입·로그인 비즈니스 로직  
   - 기존 `kakaoService` 흐름과 통일성 유지 (중복 조회 → 저장 또는 조회 → JWT 발급)  
   - 주요 단계별 주석으로 코드 내 과정 설명  

3. **AppleProperties & SocialConfig**  
   - `apple.*` 설정 바인딩 (`client_id`, `team_id`, `key.path`, `tokenUrl` 등)  
   - 외부 API 호출 간소화를 위한 `RestTemplate` 빈  


## 협의가 필요한 부분 - NONCE
`nonce`는 프론트엔드에서 생성해서 Authorization 요청 시 함께 전송하는 값으로, 이를 검증하려면 애플 회원가입/로그인 때 해당 값을 백엔드에 전달해주어야 해 프론트 측과 협의가 필요합니다. 


## 추천 자료 (읽으면 좋은 글)
- [Apple ID 토큰 검증 이해하기](https://2jaebbang.tistory.com/200)  

closes #25 