### PR TITLE
feat: FCM 기반 푸시 알림 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,5 @@ out/
 
 ### application property ###
 *.yml
-!/src/main/resources/key/
+/src/main/resources/key/**
+/src/main/resources/firebase/**

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	// STOMP 클라이언트 지원 (브라우저와의 통신을 위한 sockjs)
 	implementation 'org.webjars:sockjs-client:1.5.1'
 	implementation 'org.webjars:stomp-websocket:2.3.4'
+
+	// fcm
+	implementation 'com.google.firebase:firebase-admin:9.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/glue/glue_be/auth/dto/request/AppleSignInRequestDto.java
+++ b/src/main/java/org/glue/glue_be/auth/dto/request/AppleSignInRequestDto.java
@@ -4,5 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 
 public record AppleSignInRequestDto(
         @NotBlank(message = "Authorization code는 필수 입력값입니다.")
-        String authorizationCode) {
+        String authorizationCode,
+
+        @NotBlank(message = "FCM 토큰은 필수 입력값입니다.")
+        String fcmToken) {
 }

--- a/src/main/java/org/glue/glue_be/auth/dto/request/KakaoSignInRequestDto.java
+++ b/src/main/java/org/glue/glue_be/auth/dto/request/KakaoSignInRequestDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public class KakaoSignInRequestDto {
 
-	String kakaoToken;
+    String kakaoToken;
+    String fcmToken;
 
 }

--- a/src/main/java/org/glue/glue_be/auth/service/AuthService.java
+++ b/src/main/java/org/glue/glue_be/auth/service/AuthService.java
@@ -85,6 +85,7 @@ public class AuthService {
         // 2.5. 유저를 조회하고 없다면 401 예외 발생
         User user = userRepository.findByOauthId(oauthId).orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "해당 사용자는 존재하지 않습니다."));
+        user.changeFcmToken(requestDto.getFcmToken());
 
         // 3. 자체 엑세스 토큰을 발행 후 리턴
         return KakaoSignInResponseDto.builder().accessToken(getToken(user.getUuid())).build();
@@ -131,6 +132,7 @@ public class AuthService {
         User user = userRepository.findByOauthId(appleUserInfo.getSubject())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED,
                         "해당 Apple 계정 사용자가 존재하지 않습니다."));
+        user.changeFcmToken(requestDto.fcmToken());
 
         UserAuthentication authentication = new UserAuthentication(user.getUuid(), null, null);
         String jwtToken = jwtTokenProvider.generateToken(authentication);

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -57,10 +57,13 @@ public class User extends BaseEntity {
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
     private ProfileImage profileImage;
 
+    @Column(name = "fcm_token")
+    private String fcmToken;
 
     @Builder
     public User(UUID uuid, String oauthId, String userName, String nickname, Integer gender, LocalDate birth,
-                Integer nation, String description, Integer certified, Integer major, Integer majorVisibility) {
+                Integer nation, String description, Integer certified, Integer major, Integer majorVisibility
+    ) {
         this.uuid = uuid;
         this.oauthId = oauthId;
         this.userName = userName;
@@ -72,6 +75,7 @@ public class User extends BaseEntity {
         this.certified = certified;
         this.major = major;
         this.majorVisibility = majorVisibility;
+        this.fcmToken = null;
     }
 
     public void changeName(String name) {
@@ -90,8 +94,12 @@ public class User extends BaseEntity {
         this.description = description;
     }
 
-    public void changeCertified(int certified){
+    public void changeCertified(int certified) {
         this.certified = certified;
+    }
+
+    public void changeFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 
 }

--- a/src/main/java/org/glue/glue_be/util/fcm/config/FirebaseConfig.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/config/FirebaseConfig.java
@@ -1,0 +1,33 @@
+package org.glue.glue_be.util.fcm.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+@Slf4j
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void init() {
+        try {
+            InputStream serviceAccount = new ClassPathResource("firebase/serviceAccountKey.json").getInputStream();
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials( GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()){
+                FirebaseApp.initializeApp(options);
+                log.info("Firebase 초기화에 성공했습니다.");
+            }
+        } catch (IOException e) {
+            log.error("Firebase 초기화에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/org/glue/glue_be/util/fcm/controller/FcmController.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/controller/FcmController.java
@@ -1,0 +1,38 @@
+package org.glue.glue_be.util.fcm.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.glue.glue_be.common.response.BaseResponse;
+import org.glue.glue_be.util.fcm.dto.FcmSendDto;
+import org.glue.glue_be.util.fcm.dto.MultiFcmSendDto;
+import org.glue.glue_be.util.fcm.response.FcmResponseStatus;
+import org.glue.glue_be.util.fcm.service.FcmService;
+import org.springframework.web.bind.annotation.*;
+
+// 테스트 용
+@RestController
+@Slf4j
+@RequestMapping("/api/fcm")
+public class FcmController {
+
+    final FcmService fcmService;
+
+    public FcmController(FcmService fcmService) {
+        this.fcmService = fcmService;
+    }
+
+    // 단일 기기로 fcm 발송
+    @PostMapping("/single")
+    public BaseResponse<Void> sendSingle(@RequestBody FcmSendDto dto) {
+        fcmService.sendMessageByFcm(dto);
+        return new BaseResponse<>(FcmResponseStatus.FCM_SEND_SUCCESS);
+    }
+
+    // 여러 기기로 fcm 발송
+    @PostMapping("/multi")
+    public BaseResponse<Void> sendMulti(@RequestBody MultiFcmSendDto dto) {
+        fcmService.sendMultiMessage(dto);
+        return new BaseResponse<>(FcmResponseStatus.FCM_MULTICAST_SUCCESS);
+    }
+
+
+}

--- a/src/main/java/org/glue/glue_be/util/fcm/controller/FcmController.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/controller/FcmController.java
@@ -23,7 +23,7 @@ public class FcmController {
     // 단일 기기로 fcm 발송
     @PostMapping("/single")
     public BaseResponse<Void> sendSingle(@RequestBody FcmSendDto dto) {
-        fcmService.sendMessageByFcm(dto);
+        fcmService.sendMessage(dto);
         return new BaseResponse<>(FcmResponseStatus.FCM_SEND_SUCCESS);
     }
 

--- a/src/main/java/org/glue/glue_be/util/fcm/dto/FcmSendDto.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/dto/FcmSendDto.java
@@ -1,0 +1,20 @@
+package org.glue.glue_be.util.fcm.dto;
+
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmSendDto {
+        private String token;
+        private String title;
+        private String body;
+
+        @Builder(toBuilder = true)
+        public FcmSendDto(String token, String title, String body) {
+                this.token = token;
+                this.title = title;
+                this.body = body;
+        }
+}
+

--- a/src/main/java/org/glue/glue_be/util/fcm/dto/MultiFcmSendDto.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/dto/MultiFcmSendDto.java
@@ -1,0 +1,20 @@
+package org.glue.glue_be.util.fcm.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MultiFcmSendDto {
+    private List<String> tokens;
+    private String title;
+    private String body;
+
+    @Builder(toBuilder = true)
+    public MultiFcmSendDto(List<String> tokens, String title, String body) {
+        this.tokens = tokens;
+        this.title = title;
+        this.body = body;
+    }
+}

--- a/src/main/java/org/glue/glue_be/util/fcm/response/FcmResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/response/FcmResponseStatus.java
@@ -1,0 +1,23 @@
+package org.glue.glue_be.util.fcm.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.glue.glue_be.common.response.ResponseStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum FcmResponseStatus implements ResponseStatus {
+
+    FCM_SEND_SUCCESS     (HttpStatus.OK,                   true,  200, "FCM 단일 전송에 성공했습니다"),
+    FCM_SEND_ERROR       (HttpStatus.INTERNAL_SERVER_ERROR,false,500, "FCM 단일 전송에 실패했습니다"),
+
+    FCM_MULTICAST_SUCCESS(HttpStatus.OK,                   true,  200, "단체 FCM 전송에 성공했습니다"),
+    FCM_MULTICAST_ERROR  (HttpStatus.INTERNAL_SERVER_ERROR,false,500, "단체 FCM 전송에 실패했습니다");
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/org/glue/glue_be/util/fcm/service/FcmService.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/service/FcmService.java
@@ -1,0 +1,55 @@
+package org.glue.glue_be.util.fcm.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import lombok.extern.slf4j.Slf4j;
+import org.glue.glue_be.common.exception.BaseException;
+import org.glue.glue_be.util.fcm.dto.FcmSendDto;
+import org.glue.glue_be.util.fcm.dto.MultiFcmSendDto;
+import org.glue.glue_be.util.fcm.response.FcmResponseStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class FcmService {
+    public void sendMessageByFcm(FcmSendDto fcmSendDto) {
+        Message message = Message.builder()
+                .setNotification(Notification.builder()
+                        .setTitle(fcmSendDto.getTitle())
+                        .setBody(fcmSendDto.getBody())
+                        .build())
+                .setToken(fcmSendDto.getToken())
+                .build();
+
+        try {
+            log.info("FCM 단일 전송 성공");
+            FirebaseMessaging.getInstance().send(message);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 단일 전송 실패", e);
+            throw new BaseException(FcmResponseStatus.FCM_SEND_ERROR, e.getMessage());
+        }
+    }
+
+    public void sendMultiMessage(MultiFcmSendDto multiFcmSendDto) {
+        MulticastMessage message = MulticastMessage.builder()
+                .setNotification(Notification.builder()
+                        .setTitle(multiFcmSendDto.getTitle())
+                        .setBody(multiFcmSendDto.getBody())
+                        .build())
+                .addAllTokens(multiFcmSendDto.getTokens())
+                .build();
+
+        try {
+            log.info("FCM 단체 전송 성공");
+            FirebaseMessaging.getInstance().sendMulticast(message);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 단체 전송 실패", e);
+            throw new BaseException(FcmResponseStatus.FCM_MULTICAST_ERROR, e.getMessage());
+        }
+    }
+
+
+}

--- a/src/main/java/org/glue/glue_be/util/fcm/service/FcmService.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/service/FcmService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class FcmService {
-    public void sendMessageByFcm(FcmSendDto fcmSendDto) {
+    public void sendMessage(FcmSendDto fcmSendDto) {
         Message message = Message.builder()
                 .setNotification(Notification.builder()
                         .setTitle(fcmSendDto.getTitle())


### PR DESCRIPTION
# 구현사항
- `fcmToken`, `title`, `body`를 입력받아 푸시 알림을 전송하는 기능을 구현했습니다.
- 쪽지 전송 등 알림을 보낼 일이 필요한 경우, `FcmService`에서 `sendMessage`와 `sendMultiMessage`을 사용하면 됩니다.
- 기능 확인을 위한 테스트용 `FcmController`을 추가했습니다. (추후 삭제 예정)

푸시 알림 구현 방법으로 FCM, SSE, WebSocket 등을 고려했으나, 네트워크 연결을 지속하지 않아도 되는 FCM 방식으로 확정하였습니다.


# 필요한 파일
- 디코에 `serviceAccountKey.json` 파일을 올려두었습니다. 프로젝트 `resources/firebase` 디렉토리에 배치하면 됩니다.
<img width="320" alt="스크린샷 2025-05-06 오후 2 37 02" src="https://github.com/user-attachments/assets/e43ab636-3426-424b-a640-1d4202d1ba6c" />


# 프론트 측과 협의
- 현재 `title`과 `body`만 받아 푸시 알림을 전송합니다. (알림 표시 및 클릭 시 앱 내 이동 로직은 프론트에서 구현이 필요합니다.)
- 다만 쪽지 전송 시 알림을 클릭하면 해당 쪽지 화면으로 바로 이동하거나, 이미지 삽입 등 추가 커스텀이 필요할 경우 프론트나 디자이너와 협의가 필요합니다.
  - ex) 알림 페이로드에 `{route: message}` 필드 추가

[공식 문서](https://firebase.google.com/docs/cloud-messaging/send-message?hl=ko&_gl=1*1oy2sne*_up*MQ..*_ga*NTI5MDcwMjk3LjE3NDY1MTA5Mzg.*_ga_CW55HF8NVT*czE3NDY1MTA5MzgkbzEkZzAkdDE3NDY1MTA5MzgkajAkbDAkaDA.)


# 성공적으로 뜬 알림
- 임의로 플러터를 통해 앱을 만들어서 아래 JSON 예시로 테스트했으며, 정상적으로 푸시가 전송되었습니다.

```
{
  "token": "${기기의 fcmToken}",
  "title": "테스트 제목",
  "body": "테스트 메시지 내용입니다"
}
```

<img width="337" alt="스크린샷 2025-05-06 오후 1 51 57" src="https://github.com/user-attachments/assets/39c3e17f-7b75-40b6-a386-5b5b742ae48d" />


closes #36 
