### PR TITLE
fix: UUIDStringConverter 추가 후 userUuid에 적용

### DIFF
--- a/src/main/java/org/glue/glue_be/common/config/UUIDStringConverter.java
+++ b/src/main/java/org/glue/glue_be/common/config/UUIDStringConverter.java
@@ -1,0 +1,18 @@
+package org.glue.glue_be.common.config;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.UUID;
+
+@Converter(autoApply = true)
+public class UUIDStringConverter implements AttributeConverter<UUID, String> {
+    @Override
+    public String convertToDatabaseColumn(UUID attribute) {
+        return attribute == null ? null : attribute.toString();
+    }
+
+    @Override
+    public UUID convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : UUID.fromString(dbData);
+    }
+}

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import lombok.*;
 import org.glue.glue_be.common.BaseEntity;
 import org.glue.glue_be.common.config.LocalDateStringConverter;
+import org.glue.glue_be.common.config.UUIDStringConverter;
 
 @Getter
 @Entity
@@ -20,6 +21,7 @@ public class User extends BaseEntity {
     private Long userId;
 
     @Column(name = "user_uuid", nullable = false, unique = true, length = 36)
+    @Convert(converter = UUIDStringConverter.class)
     private UUID uuid;
 
     @Column(name = "oauth_id", nullable = false, unique = true)


### PR DESCRIPTION
저번과 비슷한 문제를 발견하여 급하게 PR 올립니다. ([참고 PR](https://github.com/Sadajo/Glue_BE/pull/22))

- 저번에는 `LocalDate`와 `LocalDateTime`이라는 자료형을 SQLite에서 지원하지 않아 발생했던 문제였습니다.
- 이번엔 `UUID`라는 자료형 미지원으로 인해 생긴 문제였습니다.
- 따라서 `UUIDStringConverter`를 만들고 `userUuid`에 적용했습니다.

+) 참고: 테스트해볼 수 있는 몇몇의 uuid를 공유드립니다. (랜덤한 uuid)
b2d6f7c9-a842-41e5-b390-63487e10d9fc
c3e7f8d0-b953-42f6-c4a1-74598f21e0ad
d4f8f9e1-c064-53a7-d5b2-85609a32f1be