### PR TITLE
feat: 이메일 인증 코드 기능 구현 (with Redis)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
 	// Webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	// JWT token
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
@@ -69,6 +70,9 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3:2.27.3'
 	implementation 'software.amazon.awssdk:s3control:2.27.3'
 	implementation 'software.amazon.awssdk:s3outposts:2.27.3'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 }
 

--- a/src/main/java/org/glue/glue_be/auth/controller/AuthController.java
+++ b/src/main/java/org/glue/glue_be/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package org.glue.glue_be.auth.controller;
 
 import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.service.AuthService;
 import org.glue.glue_be.common.response.BaseResponse;
 import org.springframework.validation.annotation.Validated;
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 
 @RestController
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Validated
 @RequestMapping("/api/auth")
 public class AuthController {

--- a/src/main/java/org/glue/glue_be/auth/controller/AuthController.java
+++ b/src/main/java/org/glue/glue_be/auth/controller/AuthController.java
@@ -1,0 +1,34 @@
+package org.glue.glue_be.auth.controller;
+
+
+import jakarta.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import org.glue.glue_be.auth.service.AuthService;
+import org.glue.glue_be.common.response.BaseResponse;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@AllArgsConstructor
+@Validated
+@RequestMapping("/api/auth")
+public class AuthController {
+
+	private final AuthService authService;
+
+	@PostMapping("/code")
+	BaseResponse<Void> sendCode(@RequestParam("email") @Email(message = "유효한 이메일 형식이 아닙니다") String email) {
+		authService.sendCode(email);
+		return new BaseResponse<>();
+	}
+
+	@GetMapping("/verify-code")
+	BaseResponse<Boolean> verifyCode(
+		@RequestParam("email") @Email(message = "유효한 이메일 형식이 아닙니다") String email,
+		@RequestParam("code") String code) {
+		authService.verifyCode(email, code);
+		return new BaseResponse<>(true);
+	}
+
+}

--- a/src/main/java/org/glue/glue_be/auth/response/AuthResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/auth/response/AuthResponseStatus.java
@@ -1,0 +1,28 @@
+package org.glue.glue_be.auth.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.glue.glue_be.common.response.ResponseStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum AuthResponseStatus implements ResponseStatus {
+
+	EXPIRE_CODE(HttpStatus.NOT_FOUND, false, 400, "코드값이 만료됐습니다."),
+	FALSE_CODE(HttpStatus.NOT_FOUND, false, 400, "코드값이 틀렸습니다."),
+	FAIL_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "이메일 전송에 실패했습니다."),
+
+	;
+
+
+	private final HttpStatusCode httpStatusCode;
+	private final boolean isSuccess;
+	private final int code;
+	private final String message;
+}
+
+
+

--- a/src/main/java/org/glue/glue_be/auth/service/MailService.java
+++ b/src/main/java/org/glue/glue_be/auth/service/MailService.java
@@ -1,0 +1,47 @@
+package org.glue.glue_be.auth.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+	@Value("${spring.mail.username}")
+	private String from;
+
+
+	private final JavaMailSender mailSender;
+
+
+	public void sendCodeEmail(String email, String code) {
+		try {
+			SimpleMailMessage message = new SimpleMailMessage();
+			message.setTo(email);
+			message.setFrom(from);
+			message.setSubject("Glue 서비스 인증 코드 안내");
+			message.setText(
+				String.format(
+					"안녕하세요,\n\n" +
+						"요청하신 인증 코드는 다음과 같습니다:\n\n" +
+						"%s\n\n" +
+						"해당 코드는 5분 동안만 유효합니다.\n\n" +
+						"감사합니다.", code
+				)
+			);
+
+			mailSender.send(message);
+		} catch (MailSendException e) {
+			throw new MailSendException("email 코드 전송에 실패했습니다", e);
+		}
+	}
+
+
+
+}

--- a/src/main/java/org/glue/glue_be/redis/RedisConfig.java
+++ b/src/main/java/org/glue/glue_be/redis/RedisConfig.java
@@ -1,0 +1,24 @@
+package org.glue.glue_be.redis;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+}

--- a/src/main/java/org/glue/glue_be/redis/RedisUtil.java
+++ b/src/main/java/org/glue/glue_be/redis/RedisUtil.java
@@ -1,0 +1,61 @@
+package org.glue.glue_be.redis;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Random;
+
+
+@RequiredArgsConstructor
+@Service
+public class RedisUtil {
+
+	@Value("${spring.mail.auth-code-expiration-millis}")
+	private int mailCodeDuration;
+
+	private final StringRedisTemplate template; // 문자열 키 조작에 특화된 템플릿 객체
+
+
+	// key에 대응하는 value값 가져오기
+	public String getData(String key) {
+		ValueOperations<String, String> valueOperations = template.opsForValue();
+		return valueOperations.get(key);
+	}
+
+	// key에 해당하는 데이터 존재여부 확인
+	public boolean existData(String key) {
+		return template.hasKey(key);
+	}
+
+	// 유효기간 존재하는 key-value 데이터 생성
+	public void setDataExpire(String key, String value) {
+		ValueOperations<String, String> valueOperations = template.opsForValue();
+		valueOperations.set(key, value, Duration.ofMillis(mailCodeDuration));
+	}
+
+	// key에 해당하는 데이터 삭제
+	public void deleteData(String key) {
+		template.delete(key);
+	}
+
+	// 이메일 인증용 6자리 난수 코드 생성
+	public String createdCertifyNum() {
+		Random random = new Random();
+
+		// random.nextInt는 인자값 미만의 난수 정수를 생성.
+		return String.format("%06d", random.nextInt(1000000));
+	}
+
+	public void setCodeData(String email, String code) {
+		// 1. 만약 이메일을 키로 하는 데이터가 redis에 존재 시 일단 삭제
+		if (existData(email)) deleteData(email);
+
+		// 2. key를 이메일, code를 value로 하는 데이터 생성해 redis에 저장
+		setDataExpire(email, code);
+	}
+}


### PR DESCRIPTION
## 구현사항

서비스에 Redis를 도입했습니다. 인증 코드를 디비에서 처리하지 않아도 되고 레디스 데이터 자동 만료 삭제 기능이 이메일 인증코드 기능에 딱 어울려서 도입했습니다. 지금은 빠른 구현을 위해 제 로컬에 redis를 설치하여 개발했으며 추후 redis 도커 이미지를 띄우는 방식으로 전환할 예정입니다.

이를 이용해 2개의 API를 구현했습니다.
1. 이메일 인증코드 송신
- 패러미터에 이메일을 담아 보내면 랜덤 코드를 이메일로 보냅니다. 송신 이메일은 yml에 적혀있듯 ex-project의 이메일입니다.

<img width="565" alt="image" src="https://github.com/user-attachments/assets/549fbca9-10af-48cc-8c66-bbd6bfff052b" />

<img width="326" alt="image" src="https://github.com/user-attachments/assets/87ec77fb-9df5-418f-9d5e-6b8d3f29ba88" />



2. 인증코드 검증
- 처음엔 1번 api 리턴값으로 코드를 보내 프론트 자체에서 처리하려 하다가 보안 문제가 있을 것 같아 검증도 api적으로 하게끔 했습니다.
- redis엔 1번에서 입력받은 이메일을 key, 난수값 코드를 value로 하여 저장하고 있습니다.
- 사용자 입력과 레디스 입력 코드 값을 비교합니다.

<img width="711" alt="image" src="https://github.com/user-attachments/assets/3d846d4e-23b1-4bdd-8cff-9830c8a6821a" />


원래 유저 엔티티 변경도 같이 하려 했으나 로직 변경이 꽤 크게 일어날 것 같아 이 작업은 PR을 따로 파야할 것 같습니다

close #46

