### PR TITLE
feat: 푸시 알림 전송 + 알림 토글 추가

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/controller/DmChatController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/DmChatController.java
@@ -82,13 +82,4 @@ public class DmChatController {
         DmMessageResponse response = dmChatService.processDmMessage(dmChatRoomId, request, auth.getUserId());
         return ResponseEntity.ok(response);
     }
-
-//    // Websocket: Dm창 동시 접속 시 곧바로 읽음 처리
-//    // @RequestMapping("/api/dm")과 @MessageMapping는 독립적으로 작동하기 때문에 /dm을 별도로 붙여줌
-//    @MessageMapping("/dm/{dmChatRoomId}/readMessage")
-//    public void readDmMessage(@DestinationVariable Long dmChatRoomId, @Payload DmMessageReadRequest request) {
-//        // 읽음 상태 처리
-//        System.out.println("읽음 처리 요청 - 채팅방: " + dmChatRoomId + ", 사용자: " + request.getReceiverId());
-//        dmChatService.markMessagesAsRead(dmChatRoomId, request.getReceiverId());
-//    }
 }

--- a/src/main/java/org/glue/glue_be/chat/controller/DmChatController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/DmChatController.java
@@ -3,23 +3,15 @@ package org.glue.glue_be.chat.controller;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
 import org.glue.glue_be.chat.dto.request.DmChatRoomCreateRequest;
-import org.glue.glue_be.chat.dto.request.DmChatRoomJoinRequest;
-import org.glue.glue_be.chat.dto.request.DmMessageReadRequest;
 import org.glue.glue_be.chat.dto.request.DmMessageSendRequest;
 import org.glue.glue_be.chat.dto.response.*;
 import org.glue.glue_be.chat.service.DmChatService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/dm")
@@ -40,6 +32,13 @@ public class DmChatController {
     public ResponseEntity<DmChatRoomDetailResponse> getDmChatRoomDetail(@PathVariable Long dmChatRoomId, @AuthenticationPrincipal CustomUserDetails auth) {
         DmChatRoomDetailResponse response = dmChatService.getDmChatRoomDetail(dmChatRoomId, Optional.ofNullable(auth.getUserId()));
         return ResponseEntity.ok(response);
+    }
+
+    // 채팅방 알림 상태 토글
+    @PutMapping("/{dmChatRoomId}/toggle-push-notification")
+    public Integer togglePushNotification(
+            @PathVariable Long dmChatRoomId, @AuthenticationPrincipal CustomUserDetails auth) {
+        return dmChatService.toggleDmPushNotification(dmChatRoomId, 1L);
     }
 
     // 내가 호스트인 DM 채팅방 목록 조회

--- a/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
@@ -31,19 +31,6 @@ public abstract class CommonChatService {
     @Autowired protected SimpMessagingTemplate messagingTemplate;
     @Autowired private SimpUserRegistry simpUserRegistry;
 
-    protected User getUserById(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new UserException.UserNotFoundException(userId));
-    }
-
-    protected Meeting getMeetingById(Long meetingId) {
-        return meetingRepository.findByMeetingId(meetingId);
-    }
-
-    protected void validateChatRoomUsers(List<Long> userIds, Long currentUserId) {
-        // 기본 구현 없음
-    }
-
     // 채팅방 생성
     protected <REQ, C, UC, R> R createChatRoom(
             REQ request,
@@ -276,6 +263,7 @@ public abstract class CommonChatService {
             M message,
             C chatRoom,
             Long senderId,
+            String chatType,
             Function<M, String> contentExtractor,
             Function<M, User> senderExtractor,
             Function<C, List<UC>> participantsGetter,
@@ -297,9 +285,6 @@ public abstract class CommonChatService {
 
         // 채팅방 참여자 목록 조회
         List<UC> participants = participantsGetter.apply(chatRoom);
-
-        // 채팅방 유형 (일반적으로 구현 클래스에 의해 결정됨)
-        String chatType = getChatType(chatRoom);
 
         // 발신자를 제외한 모든 참여자에게 알림 전송 시도
         for (UC participant : participants) {
@@ -334,13 +319,16 @@ public abstract class CommonChatService {
         }
     }
 
-    // 채팅방 ID 추출 메서드 (구현 클래스에서 오버라이드)
-    protected <C> Long getChatRoomId(C chatRoom) {
-        throw new UnsupportedOperationException("구현 클래스에서 오버라이드해야 합니다.");
+    protected User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException.UserNotFoundException(userId));
     }
 
-    // 채팅 유형 반환 메서드 (구현 클래스에서 오버라이드)
-    protected <C> String getChatType(C chatRoom) {
+    protected Meeting getMeetingById(Long meetingId) {
+        return meetingRepository.findByMeetingId(meetingId);
+    }
+
+    protected void validateChatRoomUsers(List<Long> userIds, Long currentUserId) {
         throw new UnsupportedOperationException("구현 클래스에서 오버라이드해야 합니다.");
     }
 

--- a/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
@@ -10,23 +10,26 @@ import org.glue.glue_be.user.exception.UserException;
 import org.glue.glue_be.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.user.SimpSession;
+import org.springframework.messaging.simp.user.SimpSubscription;
+import org.springframework.messaging.simp.user.SimpUser;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.*;
+import java.util.Map;
+import java.util.HashMap;
 
 @Slf4j
 public abstract class CommonChatService {
 
-    @Autowired
-    protected UserRepository userRepository;
-    @Autowired
-    protected MeetingRepository meetingRepository;
-    @Autowired
-    protected ParticipantRepository participantRepository;
-    @Autowired
-    protected SimpMessagingTemplate messagingTemplate;
+    @Autowired protected UserRepository userRepository;
+    @Autowired protected MeetingRepository meetingRepository;
+    @Autowired protected ParticipantRepository participantRepository;
+    @Autowired protected SimpMessagingTemplate messagingTemplate;
+    @Autowired private SimpUserRegistry simpUserRegistry;
 
     protected User getUserById(Long userId) {
         return userRepository.findById(userId)
@@ -54,13 +57,9 @@ public abstract class CommonChatService {
             BiFunction<C, Integer, R> existingResponseCreator,
             Consumer<UC> userChatroomSaver) {
 
-        // 현재 사용자 조회
+        // 현재 사용자 조회, 미팅 ID 추출, 사용자 ID 목록 추출
         User currentUser = getUserById(userId);
-
-        // 미팅 ID 추출
         Long meetingId = meetingIdExtractor.apply(request);
-
-        // 사용자 ID 목록 추출
         List<Long> userIds = userIdsExtractor.apply(request);
 
         // DM 채팅방의 경우 특별 검증 (서브클래스에서 오버라이드)
@@ -172,8 +171,31 @@ public abstract class CommonChatService {
         return responseMapper.apply(savedMessage);
     }
 
-    // 메시지 응답에 대한 웹소켓 알림 전송
-    protected <M, P> void notifyParticipantsExceptSender(
+    // 사용자의 웹소켓 연결 상태를 확인
+    protected boolean isUserConnectedToWebSocket(Long userId, String chatType) {
+        // 사용자의 구독 주소 확인
+        String destination = "/queue/" + chatType + "/" + userId;
+
+        // 모든 사용자 순회
+        for (SimpUser user : simpUserRegistry.getUsers()) {
+            // 각 사용자의 모든 세션 순회
+            for (SimpSession session : user.getSessions()) {
+                // 해당 세션의 모든 구독 확인
+                for (SimpSubscription subscription : session.getSubscriptions()) {
+                    // 구독 주소가 일치하면 연결된 것으로 판단
+                    if (subscription.getDestination().equals(destination)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    // 온라인 상태인 유저들에게 웹소켓 알림 전송
+    // convertAndSend() 매소드가 연결 상태를 자체적으로 확인한다!
+    protected <M, P> void sendWebSocketMessageToOnlineReceivers(
             List<P> participants,
             Long senderId,
             String destination,
@@ -215,6 +237,79 @@ public abstract class CommonChatService {
     // 알림 전송
     protected <T> void sendNotificationToUser(Long userId, String endpoint, T payload) {
         messagingTemplate.convertAndSend("/queue/" + endpoint + "/" + userId, payload);
+    }
+
+    // FCM 알림 전송
+    protected <C, M, UC, NT> void sendPushNotificationsToOfflineReceivers(
+            M message,
+            C chatRoom,
+            Long senderId,
+            Function<M, String> contentExtractor,
+            Function<M, User> senderExtractor,
+            Function<C, List<UC>> participantsGetter,
+            Function<UC, User> userExtractor,
+            Function<UC, Integer> notificationSettingGetter,
+            BiPredicate<Long, String> isUserConnected,
+            TriFunction<User, User, String, NT> notificationBuilder,
+            Consumer<NT> notificationSender) {
+
+        // 메시지 발신자 정보
+        User sender = senderExtractor.apply(message);
+
+        // 메시지 내용
+        String content = contentExtractor.apply(message);
+        // 내용이 너무 길 경우 잘라내기
+        if (content.length() > 100) {
+            content = content.substring(0, 97) + "...";
+        }
+
+        // 채팅방 참여자 목록 조회
+        List<UC> participants = participantsGetter.apply(chatRoom);
+
+        // 채팅방 유형 (일반적으로 구현 클래스에 의해 결정됨)
+        String chatType = getChatType(chatRoom);
+
+        // 발신자를 제외한 모든 참여자에게 알림 전송 시도
+        for (UC participant : participants) {
+            User recipientUser = userExtractor.apply(participant);
+            Long recipientId = recipientUser.getUserId();
+
+            // 발신자에게는 알림을 보내지 않음
+            if (recipientId.equals(senderId)) {
+                continue;
+            }
+
+            // 알림 설정 확인 (1인 경우에만 알림 전송)
+            Integer notificationSetting = notificationSettingGetter.apply(participant);
+            if (notificationSetting != 1) {
+                continue;
+            }
+
+            // 웹소켓 연결 상태 확인 (연결되어 있지 않은 경우에만 알림 전송)
+            if (isUserConnected.test(recipientId, chatType)) {
+                continue;
+            }
+
+            // 알림 객체 생성
+            NT notification = notificationBuilder.apply(
+                    sender,
+                    recipientUser,
+                    content
+            );
+
+            // 알림 전송
+            notificationSender.accept(notification);
+        }
+    }
+
+    // 채팅방 ID 추출 메서드 (구현 클래스에서 오버라이드)
+    protected <C> Long getChatRoomId(C chatRoom) {
+        throw new UnsupportedOperationException("구현 클래스에서 오버라이드해야 합니다.");
+    }
+
+    // 채팅 유형 반환 메서드 (구현 클래스에서 오버라이드)
+    protected <C> String getChatType(C chatRoom) {
+        throw new UnsupportedOperationException("구현 클래스에서 오버라이드해야 합니다.");
     }
 
     @FunctionalInterface

--- a/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
@@ -191,9 +191,9 @@ public abstract class CommonChatService {
     }
 
     // 사용자의 웹소켓 연결 상태를 확인
-    protected boolean isUserConnectedToWebSocket(Long userId, String chatType) {
+    public boolean isUserConnectedToWebSocket(Long userId, String deliveryType) {
         // 사용자의 구독 주소 확인
-        String destination = "/queue/" + chatType + "/" + userId;
+        String destination = deliveryType + "/" + userId;
 
         // 모든 사용자 순회
         for (SimpUser user : simpUserRegistry.getUsers()) {
@@ -259,11 +259,11 @@ public abstract class CommonChatService {
     }
 
     // FCM 알림 전송
-    protected <C, M, UC, NT> void sendPushNotificationsToOfflineReceivers(
+    public <C, M, UC, NT> void sendPushNotificationsToOfflineReceivers(
             M message,
             C chatRoom,
             Long senderId,
-            String chatType,
+            String deliveryType,
             Function<M, String> contentExtractor,
             Function<M, User> senderExtractor,
             Function<C, List<UC>> participantsGetter,
@@ -303,7 +303,7 @@ public abstract class CommonChatService {
             }
 
             // 웹소켓 연결 상태 확인 (연결되어 있지 않은 경우에만 알림 전송)
-            if (isUserConnected.test(recipientId, chatType)) {
+            if (isUserConnected.test(recipientId, deliveryType)) {
                 continue;
             }
 

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -356,7 +356,7 @@ public class DmChatService extends CommonChatService {
                 message,
                 dmChatRoom,
                 senderId,
-                "dm",
+                "/queue/dm",
                 DmMessage::getDmMessageContent,                      // 메시지 내용 추출
                 DmMessage::getUser,                                  // 발신자 정보 추출
                 dmUserChatroomRepository::findByDmChatRoom,          // 참여자 목록 조회

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -136,6 +136,23 @@ public class DmChatService extends CommonChatService {
     // =====
 
 
+    // ===== 채팅방 알림 상태 토글 =====
+    @Transactional
+    public Integer toggleDmPushNotification(Long dmChatRoomId, Long userId) {
+        return processTogglePushNotification(
+                dmChatRoomId,
+                userId,
+                this::getChatRoomById,                   // 채팅방 조회
+                this::getUserById,                       // 사용자 조회
+                this::validateChatRoomMember,            // 채팅방 멤버 검증
+                DmUserChatroom::getPushNotificationOn,   // 현재 알림 상태 조회
+                DmUserChatroom::updatePushNotification,  // 알림 상태 업데이트
+                dmUserChatroomRepository::save           // 업데이트된 항목 저장
+        );
+    }
+    // =====
+
+
     // === 내가 호스트/참석자인 DM 채팅방 목록 조회 ===
     // 내가 호스트인 DM 채팅방 목록 조회
     @Transactional(readOnly = true)

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -356,6 +356,7 @@ public class DmChatService extends CommonChatService {
                 message,
                 dmChatRoom,
                 senderId,
+                "dm",
                 DmMessage::getDmMessageContent,                      // 메시지 내용 추출
                 DmMessage::getUser,                                  // 발신자 정보 추출
                 dmUserChatroomRepository::findByDmChatRoom,          // 참여자 목록 조회


### PR DESCRIPTION
## 구현 사항
### 1. 채팅 푸시 알림 전송 (FCM) 연동
1. 모든 참여자에게 웹소켓으로 메시지 전송 시도
   - 온라인인 사용자가 아닌 모든 참여자에게 웹소켓으로 메시지 전송 시도하는 이유: sendWebSocketMessageToOnlineReceivers 내부의 convertAndSend() 매소드가 연결 상태를 자체적으로 확인하기 때문
2. 오프라인 참여자 + 알림 설정을 켜둔 사용자에게만 푸시 알림 전송
   - 알림 내용: 100글자 이상인 부분은 ...로 흐리기
### 2. 알림 토글 추가
### 3. 코드 보기 쉽게 정리
close #50 #51 #52