### PR TITLE
feat: 그룹 채팅 추가

### DIFF
--- a/src/main/java/org/glue/glue_be/GlueBeApplication.java
+++ b/src/main/java/org/glue/glue_be/GlueBeApplication.java
@@ -3,9 +3,11 @@ package org.glue.glue_be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling // 채팅방 폭파 스케쥴링
 public class GlueBeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/glue/glue_be/GlueBeApplication.java
+++ b/src/main/java/org/glue/glue_be/GlueBeApplication.java
@@ -7,7 +7,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableScheduling // 채팅방 폭파 스케쥴링
 public class GlueBeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
@@ -1,0 +1,71 @@
+package org.glue.glue_be.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.auth.jwt.CustomUserDetails;
+import org.glue.glue_be.chat.dto.request.GroupMessageSendRequest;
+import org.glue.glue_be.chat.dto.response.*;
+import org.glue.glue_be.chat.service.GroupChatService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/group")
+@RequiredArgsConstructor
+public class GroupChatController {
+
+    private final GroupChatService groupChatService;
+
+    // 그룹 채팅방 생성
+    @GetMapping("/rooms/create/{meetingId}")
+    public ResponseEntity<GroupChatRoomCreateResult> createGroupChatRoom(@PathVariable Long meetingId, @AuthenticationPrincipal CustomUserDetails auth) {
+        GroupChatRoomCreateResult result = groupChatService.createGroupChatRoom(meetingId, auth.getUserId());
+        return ResponseEntity.status(result.status().code()).body(result);
+    }
+
+    // 채팅방 상세 정보 조회
+    @GetMapping("/rooms/{groupChatroomId}")
+    public ResponseEntity<GroupChatRoomDetailResponse> getGroupChatRoomDetail(@PathVariable Long groupChatroomId, @AuthenticationPrincipal CustomUserDetails auth) {
+        GroupChatRoomDetailResponse response = groupChatService.getGroupChatRoomDetail(groupChatroomId, auth.getUserId());
+        return ResponseEntity.ok(response);
+    }
+
+    // 채팅방 알림 상태 토글
+    @PutMapping("/{groupChatroomId}/toggle-push-notification")
+    public Integer togglePushNotification(@PathVariable Long groupChatroomId, @AuthenticationPrincipal CustomUserDetails auth) {
+        return groupChatService.toggleGroupPushNotification(groupChatroomId, auth.getUserId());
+    }
+
+    // 내가 참여 중인 그룹 채팅방 목록 조회
+    @GetMapping("/rooms/list")
+    public ResponseEntity<List<GroupChatRoomListResponse>> getGroupChatRooms(@AuthenticationPrincipal CustomUserDetails auth) {
+        List<GroupChatRoomListResponse> chatRooms = groupChatService.getGroupChatRooms(auth.getUserId());
+        return ResponseEntity.ok(chatRooms);
+    }
+
+    // 그룹 채팅방 나가기
+    @DeleteMapping("/rooms/{groupChatroomId}/leave")
+    public ResponseEntity<List<ActionResponse>> leaveChatRoom(@PathVariable Long groupChatroomId, @AuthenticationPrincipal CustomUserDetails auth) {
+        List<ActionResponse> response = groupChatService.leaveGroupChatRoom(groupChatroomId, auth.getUserId());
+        return ResponseEntity.ok(response);
+    }
+
+    // 채팅방 클릭 시, 대화 이력을 불러오면서 + 읽지 않은 메시지들 읽음으로 처리
+    @PutMapping("/{groupChatroomId}/all-messages")
+    public ResponseEntity<List<GroupMessageResponse>> getGroupMessages(@PathVariable Long groupChatroomId, @AuthenticationPrincipal CustomUserDetails auth) {
+        List<GroupMessageResponse> messages = groupChatService.getGroupMessagesByGroupChatRoomId(groupChatroomId, auth.getUserId());
+        return ResponseEntity.ok(messages);
+    }
+
+    // 메시지 전송
+    @PostMapping("/{groupChatroomId}/send-message")
+    public ResponseEntity<GroupMessageResponse> sendMessage(
+            @PathVariable Long groupChatroomId,
+            @RequestBody GroupMessageSendRequest request,
+            @AuthenticationPrincipal CustomUserDetails auth) {
+        GroupMessageResponse response = groupChatService.processGroupMessage(groupChatroomId, request, auth.getUserId());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/glue/glue_be/chat/controller/GroupChatWebSocketController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/GroupChatWebSocketController.java
@@ -1,0 +1,21 @@
+package org.glue.glue_be.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.chat.dto.request.GroupMessageReadRequest;
+import org.glue.glue_be.chat.service.GroupChatService;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+@Controller  // 웹소켓 메시지 처리를 위한 컨트롤러
+@RequiredArgsConstructor
+public class GroupChatWebSocketController {
+
+    private final GroupChatService groupChatService;
+
+    @MessageMapping("/group/{groupChatRoomId}/read-message")
+    public void readGroupMessage(@DestinationVariable Long groupChatRoomId, @Payload GroupMessageReadRequest request) {
+        groupChatService.markMessagesAsRead(groupChatRoomId, request.receiverId());
+    }
+}

--- a/src/main/java/org/glue/glue_be/chat/dto/request/GroupMessageReadRequest.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/request/GroupMessageReadRequest.java
@@ -1,0 +1,5 @@
+package org.glue.glue_be.chat.dto.request;
+
+public record GroupMessageReadRequest (
+        Long receiverId
+) {}

--- a/src/main/java/org/glue/glue_be/chat/dto/request/GroupMessageSendRequest.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/request/GroupMessageSendRequest.java
@@ -1,0 +1,5 @@
+package org.glue.glue_be.chat.dto.request;
+
+public record GroupMessageSendRequest(
+        String content
+) {}

--- a/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomCreateResult.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomCreateResult.java
@@ -1,0 +1,6 @@
+package org.glue.glue_be.chat.dto.response;
+
+public record GroupChatRoomCreateResult(
+        GroupChatRoomDetailResponse chatroom,
+        ActionResponse status
+) {}

--- a/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomDetailResponse.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomDetailResponse.java
@@ -1,0 +1,98 @@
+package org.glue.glue_be.chat.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import org.glue.glue_be.common.dto.MeetingSummary;
+import org.glue.glue_be.common.dto.UserSummary;
+import org.glue.glue_be.common.dto.UserSummaryWithHostInfo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder(toBuilder = true)
+public record GroupChatRoomDetailResponse(
+        Long groupChatroomId,
+        MeetingSummary meeting,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        List<UserSummary> participants,
+
+        @JsonProperty("participants")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        List<UserSummaryWithHostInfo> participantsWithHostInfo,
+
+        LocalDateTime createdAt,
+        Integer pushNotificationOn
+) {
+    // JSON 직렬화 시 participants 또는 participantsWithHostInfo 중 하나만 사용
+    @JsonProperty("participants")
+    public Object getParticipantsForSerialization() {
+        return participantsWithHostInfo != null ? participantsWithHostInfo : participants;
+    }
+
+    public GroupChatRoomDetailResponse withHostInfo(List<UserSummaryWithHostInfo> participantsWithHostInfo) {
+        return new GroupChatRoomDetailResponse(
+                groupChatroomId,
+                meeting,
+                null, // 기존 participants 필드를 null로 설정
+                participantsWithHostInfo,
+                createdAt,
+                pushNotificationOn
+        );
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long groupChatroomId;
+        private MeetingSummary meeting;
+        private List<UserSummary> participants;
+        private List<UserSummaryWithHostInfo> participantsWithHostInfo;
+        private LocalDateTime createdAt;
+        private Integer pushNotificationOn;
+
+        public Builder groupChatroomId(Long groupChatroomId) {
+            this.groupChatroomId = groupChatroomId;
+            return this;
+        }
+
+        public Builder meeting(MeetingSummary meeting) {
+            this.meeting = meeting;
+            return this;
+        }
+
+        public Builder participants(List<UserSummary> participants) {
+            this.participants = participants;
+            return this;
+        }
+
+        public Builder participantsWithHostInfo(List<UserSummaryWithHostInfo> participantsWithHostInfo) {
+            this.participantsWithHostInfo = participantsWithHostInfo;
+            return this;
+        }
+
+        public Builder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder pushNotificationOn(Integer pushNotificationOn) {
+            this.pushNotificationOn = pushNotificationOn;
+            return this;
+        }
+
+        public GroupChatRoomDetailResponse build() {
+            return new GroupChatRoomDetailResponse(
+                    groupChatroomId,
+                    meeting,
+                    participants,
+                    participantsWithHostInfo,
+                    createdAt,
+                    pushNotificationOn
+            );
+        }
+    }
+}

--- a/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomListResponse.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomListResponse.java
@@ -1,0 +1,63 @@
+package org.glue.glue_be.chat.dto.response;
+
+import org.glue.glue_be.common.dto.MeetingSummary;
+import org.glue.glue_be.common.dto.UserSummary;
+
+import java.time.LocalDateTime;
+
+public record GroupChatRoomListResponse(
+        Long groupChatroomId,
+        MeetingSummary meeting,
+        String lastMessage,
+        LocalDateTime lastMessageTime,
+        boolean hasUnreadMessages
+) {
+    // Static builder method to maintain compatibility with builder pattern
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    // Builder class to support the builder pattern
+    public static class Builder {
+        private Long groupChatroomId;
+        private MeetingSummary meeting;
+        private String lastMessage;
+        private LocalDateTime lastMessageTime;
+        private boolean hasUnreadMessages;
+
+        public Builder groupChatroomId(Long groupChatroomId) {
+            this.groupChatroomId = groupChatroomId;
+            return this;
+        }
+
+        public Builder meeting(MeetingSummary meeting) {
+            this.meeting = meeting;
+            return this;
+        }
+
+        public Builder lastMessage(String lastMessage) {
+            this.lastMessage = lastMessage;
+            return this;
+        }
+
+        public Builder lastMessageTime(LocalDateTime lastMessageTime) {
+            this.lastMessageTime = lastMessageTime;
+            return this;
+        }
+
+        public Builder hasUnreadMessages(boolean hasUnreadMessages) {
+            this.hasUnreadMessages = hasUnreadMessages;
+            return this;
+        }
+
+        public GroupChatRoomListResponse build() {
+            return new GroupChatRoomListResponse(
+                    groupChatroomId,
+                    meeting,
+                    lastMessage,
+                    lastMessageTime,
+                    hasUnreadMessages
+            );
+        }
+    }
+}

--- a/src/main/java/org/glue/glue_be/chat/dto/response/GroupMessageResponse.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/GroupMessageResponse.java
@@ -1,0 +1,70 @@
+package org.glue.glue_be.chat.dto.response;
+
+import org.glue.glue_be.common.dto.UserSummary;
+
+import java.time.LocalDateTime;
+
+public record GroupMessageResponse(
+        Long groupMessageId,
+        Long groupChatroomId,
+        UserSummary sender,
+        String message,
+        Integer unreadCount,
+        LocalDateTime createdAt
+) {
+    // Static builder method to maintain compatibility with builder pattern
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    // Builder class to support the builder pattern
+    public static class Builder {
+        private Long groupMessageId;
+        private Long groupChatroomId;
+        private UserSummary sender;
+        private String message;
+        private Integer unreadCount;
+        private LocalDateTime createdAt;
+
+        public Builder groupMessageId(Long groupMessageId) {
+            this.groupMessageId = groupMessageId;
+            return this;
+        }
+
+        public Builder groupChatroomId(Long groupChatroomId) {
+            this.groupChatroomId = groupChatroomId;
+            return this;
+        }
+
+        public Builder sender(UserSummary sender) {
+            this.sender = sender;
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder unreadCount(Integer unreadCount) {
+            this.unreadCount = unreadCount;
+            return this;
+        }
+
+        public Builder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public GroupMessageResponse build() {
+            return new GroupMessageResponse(
+                    groupMessageId,
+                    groupChatroomId,
+                    sender,
+                    message,
+                    unreadCount,
+                    createdAt
+            );
+        }
+    }
+}

--- a/src/main/java/org/glue/glue_be/chat/dto/response/GroupReadStatusUpdateResponse.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/GroupReadStatusUpdateResponse.java
@@ -1,0 +1,9 @@
+package org.glue.glue_be.chat.dto.response;
+
+import java.util.List;
+
+public record GroupReadStatusUpdateResponse(
+        Long groupChatroomId,
+        Long receiverId,
+        List<GroupMessageResponse> readMessages
+) {}

--- a/src/main/java/org/glue/glue_be/chat/entity/group/GroupMessage.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/group/GroupMessage.java
@@ -15,6 +15,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class GroupMessage extends BaseEntity {
 
+    public static final int UNREAD_COUNT_DEFAULT = 1;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long groupMessageId;
@@ -43,11 +45,10 @@ public class GroupMessage extends BaseEntity {
         this.groupChatroom = groupChatroom;
         this.meeting = meeting;
         this.message = message;
-        this.unreadCount = unreadCount;
+        this.unreadCount = (unreadCount == null) ? UNREAD_COUNT_DEFAULT: unreadCount;
     }
 
-    // If message editing is allowed
-    public void updateMessage(String newMessage) {
-        this.message = newMessage;
+    public void updateUnreadCount() {
+        this.unreadCount -= 1;
     }
 }

--- a/src/main/java/org/glue/glue_be/chat/entity/group/GroupUserChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/group/GroupUserChatRoom.java
@@ -34,9 +34,8 @@ public class GroupUserChatRoom extends BaseEntity {
         this.pushNotificationOn = 1; // Default value
     }
 
-    // Methods to update entity state
-    public void togglePushNotification() {
-        this.pushNotificationOn = (this.pushNotificationOn == 1) ? 0 : 1;
+    public void togglePushNotification(Integer pushNotificationOn) {
+        this.pushNotificationOn = pushNotificationOn;
     }
 
     public void setPushNotification(boolean enabled) {

--- a/src/main/java/org/glue/glue_be/chat/mapper/GroupResponseMapper.java
+++ b/src/main/java/org/glue/glue_be/chat/mapper/GroupResponseMapper.java
@@ -1,0 +1,125 @@
+package org.glue.glue_be.chat.mapper;
+
+import org.glue.glue_be.chat.dto.response.GroupChatRoomDetailResponse;
+import org.glue.glue_be.chat.dto.response.GroupChatRoomListResponse;
+import org.glue.glue_be.chat.dto.response.GroupMessageResponse;
+import org.glue.glue_be.chat.entity.group.GroupChatRoom;
+import org.glue.glue_be.chat.entity.group.GroupMessage;
+import org.glue.glue_be.chat.entity.group.GroupUserChatRoom;
+import org.glue.glue_be.common.dto.MeetingSummary;
+import org.glue.glue_be.common.dto.UserSummary;
+import org.glue.glue_be.meeting.entity.Meeting;
+import org.glue.glue_be.user.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class GroupResponseMapper {
+    String meetingImageUrl = "dummy"; //TODO
+
+    // User 엔티티를 ChatUserResponse DTO로 변환
+    public UserSummary toChatUserResponse(User user) {
+
+        return UserSummary.builder()
+                .userId(user.getUserId())
+                .userNickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .build();
+    }
+
+    // 그룹 채팅방 상세 정보 매핑
+    public GroupChatRoomDetailResponse toChatRoomDetailResponse(
+            GroupChatRoom groupChatRoom,
+            List<GroupUserChatRoom> participants,
+            Long currentUserId) {
+
+        Meeting meeting = groupChatRoom.getMeeting();
+
+        MeetingSummary meetingSummary = new MeetingSummary(
+                meeting.getMeetingId(),
+                meeting.getMeetingTitle(),
+                meetingImageUrl,
+                meeting.getCurrentParticipants()
+        );
+
+        List<UserSummary> userSummaries = participants.stream()
+                .map(participant -> {
+                    User user = participant.getUser();
+                    return new UserSummary(
+                            user.getUserId(),
+                            user.getNickname(),
+                            user.getProfileImageUrl()
+                    );
+                })
+                .collect(Collectors.toList());
+
+        // 현재 사용자의 알림 설정 조회
+        Integer pushNotificationOn = participants.stream()
+                .filter(p -> p.getUser().getUserId().equals(currentUserId))
+                .findFirst()
+                .map(GroupUserChatRoom::getPushNotificationOn)
+                .orElse(1);
+
+        return GroupChatRoomDetailResponse.builder()
+                .groupChatroomId(groupChatRoom.getGroupChatroomId())
+                .meeting(meetingSummary)
+                .participants(userSummaries)
+                .createdAt(groupChatRoom.getCreatedAt())
+                .pushNotificationOn(pushNotificationOn)
+                .build();
+    }
+
+    // 그룹 채팅방 목록 아이템 매핑
+    public GroupChatRoomListResponse toChatRoomListResponse(
+            GroupChatRoom groupChatRoom,
+            GroupMessage lastMessage,
+            boolean hasUnreadMessages,
+            int participantCount) {
+
+        Meeting meeting = groupChatRoom.getMeeting();
+        MeetingSummary meetingSummary = new MeetingSummary(
+                meeting.getMeetingId(),
+                meeting.getMeetingTitle(),
+                meetingImageUrl,
+                meeting.getCurrentParticipants()
+        );
+
+        String lastMessageContent = null;
+        UserSummary lastMessageSender = null;
+        java.time.LocalDateTime lastMessageTime = null;
+
+        if (lastMessage != null) {
+            lastMessageContent = lastMessage.getMessage();
+            lastMessageTime = lastMessage.getCreatedAt();
+        }
+
+        return GroupChatRoomListResponse.builder()
+                .groupChatroomId(groupChatRoom.getGroupChatroomId())
+                .meeting(meetingSummary)
+                .lastMessage(lastMessageContent)
+                .lastMessageTime(lastMessageTime)
+                .hasUnreadMessages(hasUnreadMessages)
+                .build();
+    }
+
+    // 그룹 메시지 매핑
+    public GroupMessageResponse toMessageResponse(GroupMessage message) {
+        User sender = message.getUser();
+        UserSummary senderSummary = new UserSummary(
+                sender.getUserId(),
+                sender.getNickname(),
+                sender.getProfileImageUrl()
+        );
+
+        return GroupMessageResponse.builder()
+                .groupMessageId(message.getGroupMessageId())
+                .groupChatroomId(message.getGroupChatroom().getGroupChatroomId())
+                .sender(senderSummary)
+                .message(message.getMessage())
+                .unreadCount(message.getUnreadCount())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupChatRoomRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,4 +21,7 @@ public interface GroupChatRoomRepository extends JpaRepository<GroupChatRoom, Lo
     // 특정 사용자가 참여한 그룹 채팅방 조회
     @Query("SELECT gc FROM GroupChatRoom gc JOIN gc.groupUserChatrooms guc WHERE guc.user.userId = :userId")
     List<GroupChatRoom> findByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT g FROM GroupChatRoom g JOIN g.meeting m WHERE m.meetingTime < :threshold")
+    List<GroupChatRoom> findByMeetingTime(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupChatRoomRepository.java
@@ -1,0 +1,23 @@
+package org.glue.glue_be.chat.repository.group;
+
+import org.glue.glue_be.chat.entity.group.GroupChatRoom;
+import org.glue.glue_be.meeting.entity.Meeting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupChatRoomRepository extends JpaRepository<GroupChatRoom, Long> {
+
+    // 미팅 ID로 그룹 채팅방 조회
+    Optional<GroupChatRoom> findByMeeting_MeetingId(Long meetingId);
+
+    // 미팅 목록으로 그룹 채팅방 목록 조회
+    List<GroupChatRoom> findByMeetingIn(List<Meeting> meetings);
+
+    // 특정 사용자가 참여한 그룹 채팅방 조회
+    @Query("SELECT gc FROM GroupChatRoom gc JOIN gc.groupUserChatrooms guc WHERE guc.user.userId = :userId")
+    List<GroupChatRoom> findByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupMessageRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupMessageRepository.java
@@ -1,0 +1,26 @@
+package org.glue.glue_be.chat.repository.group;
+
+import org.glue.glue_be.chat.entity.group.GroupChatRoom;
+import org.glue.glue_be.chat.entity.group.GroupMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupMessageRepository extends JpaRepository<GroupMessage, Long> {
+
+    // 채팅방 ID로 메시지 조회 (최신순)
+    List<GroupMessage> findByGroupChatroomOrderByCreatedAtAsc(GroupChatRoom groupChatroom);
+
+    // 채팅방의 가장 최근 메시지 조회
+    Optional<GroupMessage> findTopByGroupChatroomOrderByCreatedAtDesc(GroupChatRoom groupChatroom);
+
+    // 읽지 않은 메시지 존재 여부 확인
+    boolean existsByGroupChatroomAndUser_UserIdNotAndUnreadCount(GroupChatRoom groupChatroom, Long userId, Integer isRead);
+
+    // 읽지 않은 메시지 조회
+    @Query("SELECT gm FROM GroupMessage gm WHERE gm.groupChatroom.groupChatroomId = :groupChatroomId AND gm.user.userId != :userId AND gm.unreadCount != 0")
+    List<GroupMessage> findUnreadMessages(@Param("groupChatroomId") Long groupChatroomId, @Param("userId") Long userId);
+}

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupUserChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupUserChatRoomRepository.java
@@ -1,0 +1,24 @@
+package org.glue.glue_be.chat.repository.group;
+
+import org.glue.glue_be.chat.entity.group.GroupChatRoom;
+import org.glue.glue_be.chat.entity.group.GroupUserChatRoom;
+import org.glue.glue_be.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupUserChatRoomRepository extends JpaRepository<GroupUserChatRoom, Long> {
+
+    // 채팅방과 유저로 조회
+    Optional<GroupUserChatRoom> findByGroupChatroomAndUser(GroupChatRoom groupChatroom, User user);
+
+    // 채팅방의 모든 참여자 조회
+    List<GroupUserChatRoom> findByGroupChatroom(GroupChatRoom groupChatroom);
+
+    // 유저가 참여한 모든 채팅방 조회
+    List<GroupUserChatRoom> findByUser(User user);
+
+    // 채팅방과 유저로 삭제
+    void deleteByGroupChatroomAndUser(GroupChatRoom groupChatroom, User user);
+}

--- a/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
@@ -117,7 +117,6 @@ public abstract class CommonChatService {
     }
 
     // 채팅방 나가기
-    // 채팅방 나가기
     protected <C, UC, M> List<ActionResponse> processLeaveChatRoom(
             Long chatRoomId,
             Long userId,

--- a/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
@@ -210,39 +210,6 @@ public class GroupChatService extends CommonChatService {
                 groupChatRoomRepository::delete
         );
     }
-
-    // 미팅 일주일 후 그룹 채팅방 폭파
-    @Scheduled(cron = "0 0 0 * * *")
-    private void destroyGroupChatRoom() {
-        LocalDateTime threshold = LocalDateTime.now().minusDays(7);
-        List<GroupChatRoom> outdatedChatRooms = groupChatRoomRepository.findByMeetingTime(threshold);
-
-        for (GroupChatRoom chatRoom : outdatedChatRooms) {
-            try {
-                Meeting meeting = chatRoom.getMeeting();
-
-                if (meeting != null) {
-                    processChatRoomDestruction(chatRoom);
-                }
-            } catch (Exception e) {
-                log.error("채팅방 ID: {} 삭제 중 오류 발생: {}", chatRoom.getGroupChatroomId(), e.getMessage(), e);
-            }
-        }
-    }
-
-    // 채팅방 파괴 전용 메소드
-    private void processChatRoomDestruction(GroupChatRoom chatRoom) {
-        // 모든 메시지 삭제
-        List<GroupMessage> messages = groupMessageRepository.findByGroupChatroomOrderByCreatedAtAsc(chatRoom);
-        groupMessageRepository.deleteAll(messages);
-
-        // 모든 사용자 관계 삭제
-        List<GroupUserChatRoom> userChatRooms = groupUserChatRoomRepository.findByGroupChatroom(chatRoom);
-        groupUserChatRoomRepository.deleteAll(userChatRooms);
-
-        // 채팅방 삭제
-        groupChatRoomRepository.delete(chatRoom);
-    }
     // =====
 
 

--- a/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
@@ -1,0 +1,362 @@
+package org.glue.glue_be.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.chat.dto.request.GroupMessageSendRequest;
+import org.glue.glue_be.chat.dto.response.*;
+import org.glue.glue_be.chat.entity.group.GroupChatRoom;
+import org.glue.glue_be.chat.entity.group.GroupMessage;
+import org.glue.glue_be.chat.entity.group.GroupUserChatRoom;
+import org.glue.glue_be.chat.exception.ChatException;
+import org.glue.glue_be.chat.mapper.GroupResponseMapper;
+import org.glue.glue_be.chat.repository.group.GroupChatRoomRepository;
+import org.glue.glue_be.chat.repository.group.GroupMessageRepository;
+import org.glue.glue_be.chat.repository.group.GroupUserChatRoomRepository;
+import org.glue.glue_be.common.dto.UserSummary;
+import org.glue.glue_be.common.dto.UserSummaryWithHostInfo;
+import org.glue.glue_be.meeting.entity.Meeting;
+import org.glue.glue_be.user.entity.User;
+import org.glue.glue_be.util.fcm.dto.FcmSendDto;
+import org.glue.glue_be.util.fcm.service.FcmService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GroupChatService extends CommonChatService {
+
+    private final GroupChatRoomRepository groupChatRoomRepository;
+    private final GroupUserChatRoomRepository groupUserChatRoomRepository;
+    private final GroupMessageRepository groupMessageRepository;
+    private final GroupResponseMapper responseMapper;
+    private final FcmService fcmService;
+
+    // ===== 그룹 채팅방 생성 =====
+    @Transactional
+    public GroupChatRoomCreateResult createGroupChatRoom(Long meetingId, Long userId) {
+        // 미팅 정보 조회
+        Meeting meeting = getMeetingById(meetingId);
+        User user = getUserById(userId);
+
+        // 기존에 해당 미팅에 대한 그룹 채팅방이 있는지 확인
+        Optional<GroupChatRoom> existingChatRoom = groupChatRoomRepository.findByMeeting_MeetingId(meetingId);
+
+        if (existingChatRoom.isPresent()) {
+            // 기존 채팅방이 있으면 사용자만 추가
+            GroupChatRoom chatRoom = existingChatRoom.get();
+
+            // 이미 사용자가 채팅방에 참여 중인지 확인
+            Optional<GroupUserChatRoom> existingUserChatroom =
+                    groupUserChatRoomRepository.findByGroupChatroomAndUser(chatRoom, user);
+
+            if (existingUserChatroom.isPresent()) {
+                // 이미 참여 중이면 기존 채팅방 정보 반환
+                return new GroupChatRoomCreateResult(
+                        getGroupChatRoomDetail(chatRoom.getGroupChatroomId(), userId),
+                        new ActionResponse(200, "이미 참여 중인 채팅방입니다.")
+                );
+            } else {
+                // 채팅방에 사용자 추가
+                GroupUserChatRoom groupUserChatRoom = new GroupUserChatRoom(user, chatRoom);
+                groupUserChatRoomRepository.save(groupUserChatRoom);
+
+                return new GroupChatRoomCreateResult(
+                        getGroupChatRoomDetail(chatRoom.getGroupChatroomId(), userId),
+                        new ActionResponse(200, "기존 채팅방에 참여하였습니다.")
+                );
+            }
+        } else {
+            // 새 채팅방 생성 시 호스트 권한 확인
+            if (!user.getUserId().equals(meeting.getHost().getUserId())) {
+                throw new ChatException("미팅 호스트만 새 채팅방을 생성할 수 있습니다.");
+            }
+
+            // 새 채팅방 생성
+            GroupChatRoom newChatRoom = new GroupChatRoom(meeting);
+            GroupChatRoom savedChatRoom = groupChatRoomRepository.save(newChatRoom);
+
+            // 채팅방에 사용자 추가
+            GroupUserChatRoom groupUserChatRoom = new GroupUserChatRoom(user, savedChatRoom);
+            groupUserChatRoomRepository.save(groupUserChatRoom);
+
+            return new GroupChatRoomCreateResult(
+                    getGroupChatRoomDetail(savedChatRoom.getGroupChatroomId(), userId),
+                    new ActionResponse(201, "새 그룹 채팅방을 생성하였습니다.")
+            );
+        }
+    }
+    // =====
+
+
+    // ===== 그룹 채팅방 상세 정보 조회 =====
+    @Transactional(readOnly = true)
+    public GroupChatRoomDetailResponse getGroupChatRoomDetail(Long groupChatroomId, Long userId) {
+        // 채팅방 조회
+        GroupChatRoom groupChatRoom = getChatRoomById(groupChatroomId);
+
+        // 채팅방 참여자 목록 조회
+        List<GroupUserChatRoom> participants = groupUserChatRoomRepository.findByGroupChatroom(groupChatRoom);
+
+        // 요청한 사용자가 채팅방 참여자인지 확인
+        boolean isParticipant = participants.stream()
+                .anyMatch(participant -> participant.getUser().getUserId().equals(userId));
+
+        if (!isParticipant) {
+            throw new ChatException("해당 사용자는 채팅방 참여자가 아닙니다.");
+        }
+
+        // 응답 생성
+        GroupChatRoomDetailResponse responseWithoutHostInfo = responseMapper.toChatRoomDetailResponse(
+                groupChatRoom, participants, userId);
+
+        // 호스트 정보를 추가한 참가자 목록 생성
+        List<UserSummaryWithHostInfo> participantsWithHostInfo = participants.stream()
+                .map(participant -> {
+                    UserSummary userSummary = responseMapper.toChatUserResponse(participant.getUser());
+                    boolean isHost = determineIsHost(
+                            participant,
+                            GroupUserChatRoom::getUser,
+                            GroupUserChatRoom::getGroupChatroom,
+                            GroupChatRoom::getMeeting,
+                            Meeting::getHost
+                    );
+                    return UserSummaryWithHostInfo.from(userSummary, isHost);
+                })
+                .collect(Collectors.toList());
+
+        // 최종 응답 생성 (호스트 정보를 포함한 참가자 목록으로 업데이트)
+        return responseWithoutHostInfo.toBuilder()
+                .participantsWithHostInfo(participantsWithHostInfo)
+                .build();
+    }
+    // =====
+
+
+    // ===== 채팅방 알림 상태 토글 =====
+    @Transactional
+    public Integer toggleGroupPushNotification(Long groupChatroomId, Long userId) {
+        return processTogglePushNotification(
+                groupChatroomId,
+                userId,
+                this::getChatRoomById,                       // 채팅방 조회
+                this::getUserById,                           // 사용자 조회
+                this::validateChatRoomMember,                // 채팅방 멤버 검증
+                GroupUserChatRoom::getPushNotificationOn,    // 현재 알림 상태 조회
+                GroupUserChatRoom::togglePushNotification,   // 알림 상태 업데이트
+                groupUserChatRoomRepository::save            // 업데이트된 항목 저장
+        );
+    }
+    // =====
+
+
+    // ===== 내가 참여 중인 그룹 채팅방 목록 조회 =====
+    @Transactional(readOnly = true)
+    public List<GroupChatRoomListResponse> getGroupChatRooms(Long userId) {
+        User currentUser = getUserById(userId);
+
+        // 사용자가 참여 중인 그룹 채팅방 목록 조회
+        List<GroupChatRoom> chatRooms = groupChatRoomRepository.findByUserId(userId);
+
+        return chatRooms.stream()
+                .map(chatRoom -> {
+                    // 참여자 수 계산
+                    List<GroupUserChatRoom> participants = groupUserChatRoomRepository.findByGroupChatroom(chatRoom);
+                    int participantCount = participants.size();
+
+                    // 최근 메시지 조회
+                    GroupMessage lastMessage = groupMessageRepository.findTopByGroupChatroomOrderByCreatedAtDesc(chatRoom)
+                            .orElse(null);
+
+                    // 읽지 않은 메시지 여부 확인
+                    boolean hasUnreadMessages = groupMessageRepository.existsByGroupChatroomAndUser_UserIdNotAndUnreadCount(
+                            chatRoom, userId, 0);
+
+                    return responseMapper.toChatRoomListResponse(
+                            chatRoom, lastMessage, hasUnreadMessages, participantCount);
+                })
+                .collect(Collectors.toList());
+    }
+    // =====
+
+    // ===== 그룹 채팅방 나가기 =====
+    @Transactional
+    public List<ActionResponse> leaveGroupChatRoom(Long groupChatroomId, Long userId) {
+        return (List<ActionResponse>) processLeaveChatRoom(
+                groupChatroomId,
+                userId,
+                this::getChatRoomById,
+                this::getUserById,
+                this::validateChatRoomMember,
+                groupUserChatRoomRepository::deleteByGroupChatroomAndUser,
+                groupUserChatRoomRepository::findByGroupChatroom,
+                groupMessageRepository::findByGroupChatroomOrderByCreatedAtAsc,
+                groupMessageRepository::deleteAll,
+                groupChatRoomRepository::delete
+        );
+    }
+    // =====
+
+
+    // ===== DM방 진입 시, 대화 이력 조회 + 안 읽었던 것들 읽음 처리(실시간+비실시간) =====
+    // 대화 이력 조회 후 읽지 않은 메시지 읽음 처리
+    @Transactional
+    public List<GroupMessageResponse> getGroupMessagesByGroupChatRoomId(Long groupChatroomId, Long userId) {
+        GroupChatRoom groupChatRoom = getChatRoomById(groupChatroomId);
+        User user = getUserById(userId);
+        validateChatRoomMember(groupChatRoom, user);
+
+        // 읽지 않은 메시지 읽음 처리
+        List<GroupMessage> messages = groupMessageRepository.findByGroupChatroomOrderByCreatedAtAsc(groupChatRoom);
+        markMessagesAsRead(groupChatroomId, userId);
+
+        return messages.stream()
+                .map(responseMapper::toMessageResponse)
+                .collect(Collectors.toList());
+    }
+
+    // 안 읽었던 것들 읽음 처리하는 실시간+비실시간 로직을 공통 매소드에 전달
+    @Transactional
+    public void markMessagesAsRead(Long groupChatroomId, Long userId) {
+        processMarkAsRead(
+                groupChatroomId,
+                userId,
+                this::getChatRoomById,                           // 채팅방 조회
+                this::validateChatRoomMember,                    // 채팅방 멤버 검증
+                groupMessageRepository::findUnreadMessages,      // 읽지 않은 메시지 조회
+                GroupMessage::updateUnreadCount,                 // 읽음 처리
+                groupMessageRepository::saveAll,                 // 업데이트된 메시지 저장
+                this::notifyGroupMessageRead                     // 읽음 알림 전송
+        );
+    }
+
+    // 메시지 읽음 알림 전송
+    private void notifyGroupMessageRead(Long groupChatroomId, Long receiverId, List<GroupMessage> readMessages) {
+        if (!readMessages.isEmpty()) {
+            GroupChatRoomDetailResponse chatRoom = getGroupChatRoomDetail(groupChatroomId, receiverId);
+
+            List<GroupMessageResponse> updatedMessages = readMessages.stream()
+                    .map(responseMapper::toMessageResponse)
+                    .collect(Collectors.toList());
+
+            GroupReadStatusUpdateResponse readStatus = new GroupReadStatusUpdateResponse(
+                    groupChatroomId, receiverId, updatedMessages
+            );
+
+            // 모든 참여자에게 알림 전송 (읽은 사용자 제외)
+            for (UserSummary participant : chatRoom.participants()) {
+                if (!participant.getUserId().equals(receiverId)) {
+                    sendNotificationToUser(participant.getUserId(), "group/read", readStatus);
+                }
+            }
+        }
+    }
+    // =====
+
+
+    // ===== 그룹 메시지 전송 =====
+    @Transactional
+    public GroupMessageResponse processGroupMessage(Long groupChatroomId, GroupMessageSendRequest request, Long userId) {
+        // 메시지 저장
+        GroupMessageResponse response = saveGroupMessage(groupChatroomId, userId, request.content());
+
+        // 메시지 전송 및 알림
+        broadcastMessage(groupChatroomId, response, userId);
+
+        return response;
+    }
+
+    // 메시지 저장
+    private GroupMessageResponse saveGroupMessage(Long groupChatroomId, Long senderId, String content) {
+        GroupChatRoom groupChatRoom = getChatRoomById(groupChatroomId);
+        User sender = getUserById(senderId);
+        validateChatRoomMember(groupChatRoom, sender);
+
+        // 메시지 생성
+        GroupMessage groupMessage = new GroupMessage(
+                sender,
+                groupChatRoom,
+                groupChatRoom.getMeeting(),
+                content,
+                countOtherParticipants(groupChatRoom, senderId)
+        );
+
+        // 메시지 저장
+        GroupMessage savedMessage = groupMessageRepository.save(groupMessage);
+
+        // 응답 생성
+        return responseMapper.toMessageResponse(savedMessage);
+    }
+
+    // 채팅방 참여자 수 계산 (발신자 제외)
+    private Integer countOtherParticipants(GroupChatRoom groupChatRoom, Long senderId) {
+        List<GroupUserChatRoom> participants = groupUserChatRoomRepository.findByGroupChatroom(groupChatRoom);
+        return (int) participants.stream()
+                .filter(p -> !p.getUser().getUserId().equals(senderId))
+                .count();
+    }
+
+    // 메시지 브로드캐스트 및 알림 전송
+    private void broadcastMessage(Long groupChatroomId, GroupMessageResponse messageResponse, Long senderId) {
+        // 채팅방 정보 조회
+        GroupChatRoomDetailResponse chatRoom = getGroupChatRoomDetail(groupChatroomId, senderId);
+
+        // 1. 온라인 참여자에게 웹소켓으로 메시지 전송
+        sendWebSocketMessageToOnlineReceivers(
+                chatRoom.participants(),
+                senderId,
+                "/topic/group/",
+                messageResponse,
+                UserSummary::getUserId
+        );
+
+        // 2. 오프라인 참여자에게 푸시 알림 전송
+        GroupChatRoom groupChatRoom = getChatRoomById(groupChatroomId);
+        GroupMessage message = groupMessageRepository.findById(messageResponse.groupMessageId())
+                .orElseThrow(() -> new ChatException("메시지를 찾을 수 없습니다."));
+
+        // 오프라인 참여자에게 푸시 알림 전송
+        sendPushNotificationsToOfflineReceivers(
+                message,
+                groupChatRoom,
+                senderId,
+                "/topic/group",
+                GroupMessage::getMessage,                         // 메시지 내용 추출
+                GroupMessage::getUser,                            // 발신자 정보 추출
+                groupUserChatRoomRepository::findByGroupChatroom, // 참여자 목록 조회
+                GroupUserChatRoom::getUser,                       // 사용자 정보 추출
+                GroupUserChatRoom::getPushNotificationOn,         // 알림 설정 조회
+                this::isUserConnectedToWebSocket,                 // 웹소켓 연결 확인
+                (sender, recipient, content) -> FcmSendDto.builder() // 알림 객체 생성
+                        .title(sender.getNickname() + "님의 그룹 메시지")
+                        .body(content)
+                        .token(recipient.getFcmToken())
+                        .build(),
+                fcmService::sendMessage                           // 알림 전송
+        );
+    }
+    // =====
+
+
+    // ===== 공통 메소드 =====
+    private GroupChatRoom getChatRoomById(Long groupChatroomId) {
+        return groupChatRoomRepository.findById(groupChatroomId)
+                .orElseThrow(() -> new ChatException("그룹 채팅방을 찾을 수 없습니다."));
+    }
+
+    private GroupUserChatRoom validateChatRoomMember(GroupChatRoom chatRoom, User user) {
+        return groupUserChatRoomRepository.findByGroupChatroomAndUser(chatRoom, user)
+                .orElseThrow(() -> new ChatException("채팅방에 참여하지 않은 사용자입니다."));
+    }
+
+    @Override
+    protected void validateChatRoomUsers(List<Long> userIds, Long currentUserId) {
+        // 그룹 채팅방은 검증 로직이 필요 없음 (DM과 달리 참여자 수 제한이 없음)
+        // 단, 현재 사용자가 포함되어 있는지는 확인
+        if (!userIds.contains(currentUserId)) {
+            throw new ChatException("그룹 채팅방 생성 시 본인이 포함되어야 합니다.");
+        }
+    }
+    // =====
+}

--- a/src/main/java/org/glue/glue_be/common/dto/MeetingSummary.java
+++ b/src/main/java/org/glue/glue_be/common/dto/MeetingSummary.java
@@ -1,0 +1,8 @@
+package org.glue.glue_be.common.dto;
+
+public record MeetingSummary (
+        Long meetingId,
+        String meetingTitle,
+        String meetingImageUrl,
+        Integer currentParticipants
+) {}

--- a/src/main/java/org/glue/glue_be/common/dto/UserSummaryWithHostInfo.java
+++ b/src/main/java/org/glue/glue_be/common/dto/UserSummaryWithHostInfo.java
@@ -1,0 +1,7 @@
+package org.glue.glue_be.common.dto;
+
+public record UserSummaryWithHostInfo(UserSummary user, boolean isHost) {
+    public static UserSummaryWithHostInfo from(UserSummary user, boolean isHost) {
+        return new UserSummaryWithHostInfo(user, isHost);
+    }
+}

--- a/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
@@ -67,6 +67,9 @@ public class Meeting extends BaseEntity {
     @Column(name = "language_id", nullable = false)
     private Integer languageId;
 
+    @Column(name = "meeting_image_url", nullable = true)
+    private String meetingImageUrl;
+
     @Builder
     private Meeting(User host,
                     String meetingTitle,

--- a/src/main/java/org/glue/glue_be/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/glue/glue_be/meeting/repository/MeetingRepository.java
@@ -2,6 +2,9 @@ package org.glue.glue_be.meeting.repository;
 
 import org.glue.glue_be.meeting.entity.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +14,20 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     Meeting findByMeetingId(Long meetingId);
 
     List<Meeting> findByHost_UserId(Long userId);
+
+    @Modifying
+    @Query(value = """
+        UPDATE meeting\s
+        SET meeting_image_url = (
+            SELECT pi.image_url
+            FROM post p
+            JOIN post_image pi ON p.post_id = pi.post_id
+            WHERE p.meeting_id = meeting.meeting_id
+            AND pi.image_order = 0
+            ORDER BY p.post_id DESC
+            LIMIT 1
+        )
+        WHERE meeting_id = :meetingId
+        """, nativeQuery = true)
+    void updateMeetingImageUrl(@Param("meetingId") Long meetingId);
 }

--- a/src/main/java/org/glue/glue_be/post/service/PostService.java
+++ b/src/main/java/org/glue/glue_be/post/service/PostService.java
@@ -49,6 +49,10 @@ public class PostService {
 	private final LikeRepository likeRepository;
 	private final PostImageRepository postImageRepository;
 
+	// 게시글 사진이 추가 및 삭제될 때 meeting image url도 함께 업데이트 시키는 메소드
+	public void updateMeetingImageUrl(Long meetingId) {
+		meetingRepository.updateMeetingImageUrl(meetingId);
+	}
 
 	// 게시글 추가
 	public CreatePostResponse createPost(CreatePostRequest request, Long userId) {
@@ -110,7 +114,10 @@ public class PostService {
 			}
 		}
 
-		// 6. responseDto 생성 직후 리턴
+		// 6. 이미지가 저장된 후 미팅 대표 이미지 업데이트
+		updateMeetingImageUrl(savedMeeting.getMeetingId());
+
+		// 7. responseDto 생성 직후 리턴
 		return CreatePostResponse.builder().postId(savedPost.getId()).build();
 
 	}


### PR DESCRIPTION
## 읽음 처리 로직은 빼고 봐주세요 (이거까지 이번 PR에 하면 너무 길어질 것 같아서 일단 한 번 자름)


## 구현 사항
### 1. 추상화해둔 로직 구체화 완료
- 알림 상태 토글
- 채팅방 목록 조회
- 나가기
- 대화 내역 불러오기 + 비실시간 읽음 처리
- 메시지 전송
- 실시간 읽음 처리

### 2. 단톡 폭파 기능
- 일단 서버의 스케쥴러를 활용하여 7일 뒤에 자동으로 데이터베이스 상에서 삭제되도록 구현해둔 상태입니다.
- 아직 기획이 정해진 바가 없어, 추후 기획 나오는대로 손볼 예정입니다. (이때 나가기 기능도 기획에 맞게 함께 손볼 예정입니다.)

## 전달 사항
### 1. record 도입
- 그룹채팅 구현하며 모든 dto를 record로 바꿨습니다.
- 개발하다보니 dto는 디엠과 그룹을 함께 써도 될 것 같아, 필수 기능 구현 완료 후 합쳐볼 예정입니다.

### 2. 모임 사진 관련
- 아직 어떻게 처리해야 할지 모르겠어가지고, 꽤나 난감해서 mapper에다가 사진은 "dummy"로 일단은 넣어뒀습니다.
- 방법이 떠오르는대로 빠르게 처리하겠습니다.

## 추후 개발 내용
### 1. 읽음 처리 관련
- 이게 생각보다 꽤 많이 골치가 아픕니다.. 이래저래 계속 알아보고 있습니다만.. 

### 2. DTO 관련
- 어제 프론트분과 잠시 논의했을 때, 최적화 및 편의성을 위해 DTO에 일부 수정이 필요해 보였습니다.
- 따라서 추후 일부 수정될 것 같습니다.

close #48