### PR TITLE
fix: groupImage 채팅창에서도 보이게 수정

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/mapper/GroupResponseMapper.java
+++ b/src/main/java/org/glue/glue_be/chat/mapper/GroupResponseMapper.java
@@ -17,8 +17,6 @@ import java.util.stream.Collectors;
 
 @Component
 public class GroupResponseMapper {
-    String meetingImageUrl = "dummy"; //TODO
-
     // User 엔티티를 ChatUserResponse DTO로 변환
     public UserSummary toChatUserResponse(User user) {
 
@@ -40,7 +38,7 @@ public class GroupResponseMapper {
         MeetingSummary meetingSummary = new MeetingSummary(
                 meeting.getMeetingId(),
                 meeting.getMeetingTitle(),
-                meetingImageUrl,
+                meeting.getMeetingImageUrl(),
                 meeting.getCurrentParticipants()
         );
 
@@ -82,7 +80,7 @@ public class GroupResponseMapper {
         MeetingSummary meetingSummary = new MeetingSummary(
                 meeting.getMeetingId(),
                 meeting.getMeetingTitle(),
-                meetingImageUrl,
+                meeting.getMeetingImageUrl(),
                 meeting.getCurrentParticipants()
         );
 


### PR DESCRIPTION
앞전 pr에서 함께 반영했어야 하는데 까먹어서 따로 pr 올립니다. 죄송합니당 ㅠ
groupImage 채팅창에서 미팅 사진이 보이도록 반영했습니다.
이미지 불러오는 기준:
1. 한 미팅에 게시글이 여러개라면 -> 가장 최근에 등록된 글을 불러옴
2. 한 게시글에 사진이 여러개라면 -> image_order == 0인 사진을 불러옴
입니다.
현재는 한 미팅에 게시글 하나, 한 게시글에 사진 하나지만, 코드상으로는 여러 개가 될 수 있는 상태라 이에 맞게 설계하였습니다.