### PR TITLE
refactor: 전역 예외 처리 구조 정비 및 도메인별 일관된 예외 응답 적용

### DIFF
--- a/src/main/java/org/glue/glue_be/auth/dto/request/KakaoSignInRequestDto.java
+++ b/src/main/java/org/glue/glue_be/auth/dto/request/KakaoSignInRequestDto.java
@@ -1,7 +1,7 @@
 package org.glue.glue_be.auth.dto.request;
 
 
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.*;
 
 
 public record KakaoSignInRequestDto (
@@ -9,6 +9,7 @@ public record KakaoSignInRequestDto (
 	@NotEmpty(message = "카카오 발급 토큰값은 필수입니다")
 	String kakaoToken,
 
+	@NotBlank(message = "FCM 토큰은 필수 입력값입니다.")
     String fcmToken
 
 ) {}

--- a/src/main/java/org/glue/glue_be/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/glue/glue_be/auth/jwt/JwtAuthenticationFilter.java
@@ -7,6 +7,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.glue.glue_be.auth.response.AuthResponseStatus;
+import org.glue.glue_be.common.exception.BaseException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -23,6 +26,7 @@ import static org.glue.glue_be.auth.jwt.JwtValidationType.VALID_JWT;
 // 클라이언트가 보내는 HTTP 요청의 JWT 토큰을 확인하고 토큰이 유효할 경우 Spring Security의 인증 객체를 설정해주는 필터단
 // 한 Http 요청에 한번씩만 실행되는 OncePerRequestFilter 상속받음
 
+@Slf4j
 @Component
 @RequiredArgsConstructor // for DI fields
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -61,7 +65,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 			}
 		} catch (Exception exception) {
-			throw new RuntimeException("JWT 인증 처리 중 오류 발생", exception);
+			log.error("[JWT 인증 실패]: {}", exception.getMessage(), exception);
+			throw new BaseException(AuthResponseStatus.JWT_AUTHENTICATION_FAILED);
+
 		}
 
 		// 3. 다음 필터로 요청 전달

--- a/src/main/java/org/glue/glue_be/auth/response/AuthResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/auth/response/AuthResponseStatus.java
@@ -11,12 +11,23 @@ import org.springframework.http.HttpStatusCode;
 @AllArgsConstructor
 public enum AuthResponseStatus implements ResponseStatus {
 
-	EXPIRE_CODE(HttpStatus.NOT_FOUND, false, 400, "코드값이 만료됐습니다."),
-	FALSE_CODE(HttpStatus.NOT_FOUND, false, 400, "코드값이 틀렸습니다."),
-	FAIL_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "이메일 전송에 실패했습니다."),
+	// 소셜 로그인 관련
+	SOCIAL_API_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "소셜 로그인 서버와의 통신에 실패했습니다."),
 
-	;
+	// JWT 관련
+	JWT_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, false, 401, "JWT 인증에 실패했습니다."),
 
+	// 애플 관련
+	INVALID_AUTHORIZATION_CODE(HttpStatus.UNAUTHORIZED, false, 401, "인증 코드가 유효하지 않습니다."),
+	FAIL_APPLE_PRIVATE_KEY(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "Apple 개인 키 처리에 실패했습니다."),
+	INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, false, 401, "Apple ID 토큰이 유효하지 않습니다."),
+	EXPIRED_ID_TOKEN(HttpStatus.UNAUTHORIZED, false, 401, "Apple ID 토큰이 만료되었습니다."),
+	SIGNATURE_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, false, 401, "Apple 서명 검증에 실패했습니다."),
+
+	// 이메일 인증 관련
+	EXPIRE_CODE(HttpStatus.BAD_REQUEST, false, 400, "인증 코드가 만료되었습니다."),
+	FALSE_CODE(HttpStatus.BAD_REQUEST, false, 400, "인증 코드가 올바르지 않습니다."),
+	FAIL_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "이메일 인증 코드 전송에 실패했습니다.");
 
 	private final HttpStatusCode httpStatusCode;
 	private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/auth/service/KakaoService.java
+++ b/src/main/java/org/glue/glue_be/auth/service/KakaoService.java
@@ -5,6 +5,8 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.glue.glue_be.auth.dto.response.KakaoUserInfoResponseDto;
+import org.glue.glue_be.auth.response.AuthResponseStatus;
+import org.glue.glue_be.common.exception.BaseException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -16,45 +18,45 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Service
 public class KakaoService {
 
-	// final 사용시 DI 한번 주입해 값이 할당된 후 불변성 보장하는 키워드
-	private final String clientId;
-	private final String redirectUri;
-	private final String KAUTH_TOKEN_URL_HOST;
-	private final String KAUTH_USER_URL_HOST;
+    // final 사용시 DI 한번 주입해 값이 할당된 후 불변성 보장하는 키워드
+    private final String clientId;
+    private final String redirectUri;
+    private final String KAUTH_TOKEN_URL_HOST;
+    private final String KAUTH_USER_URL_HOST;
 
 
-	@Autowired // DI로 카카오 로그인 관련 프로퍼티 값들을 가져온다.
-	public KakaoService(@Value("${kakao.client_id}") String clientId, @Value("${kakao.redirect_uri}") String redirectUri) {
-		this.clientId = clientId;
-		this.redirectUri = redirectUri;
-		KAUTH_TOKEN_URL_HOST ="https://kauth.kakao.com";
-		KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
-	}
+    @Autowired // DI로 카카오 로그인 관련 프로퍼티 값들을 가져온다.
+    public KakaoService(@Value("${kakao.client_id}") String clientId,
+                        @Value("${kakao.redirect_uri}") String redirectUri) {
+        this.clientId = clientId;
+        this.redirectUri = redirectUri;
+        KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com";
+        KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+    }
 
 
-	// 1. 토큰으로 사용자 정보를 얻는 함수
-	public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
-		try {
-			KakaoUserInfoResponseDto userInfo = WebClient.create(KAUTH_USER_URL_HOST)
-				.get()
-				.uri(uriBuilder -> uriBuilder
-					.scheme("https")
-					.path("/v2/user/me")
-					.build(true))
-				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // 액세스 토큰 인가
-				.header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
-				.retrieve()
-				.bodyToMono(KakaoUserInfoResponseDto.class)
-				.block();
+    // 1. 토큰으로 사용자 정보를 얻는 함수
+    public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
+        try {
+            KakaoUserInfoResponseDto userInfo = WebClient.create(KAUTH_USER_URL_HOST)
+                    .get()
+                    .uri(uriBuilder -> uriBuilder
+                            .scheme("https")
+                            .path("/v2/user/me")
+                            .build(true))
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // 액세스 토큰 인가
+                    .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfoResponseDto.class)
+                    .block();
 
-			return userInfo;
+            return userInfo;
 
-		} catch (Exception e) {
-			System.err.println("카카오 사용자 정보 조회 중 오류 발생: " + e.getMessage());
-			 throw new IllegalArgumentException("잘못된 카카오 토큰입니다.");
-		}
-	}
-
+        } catch (Exception e) {
+            log.error("카카오 사용자 정보 조회 중 오류 발생: " + e);
+            throw new BaseException(AuthResponseStatus.SOCIAL_API_REQUEST_FAILED);
+        }
+    }
 
 
 }

--- a/src/main/java/org/glue/glue_be/auth/service/MailService.java
+++ b/src/main/java/org/glue/glue_be/auth/service/MailService.java
@@ -2,6 +2,9 @@ package org.glue.glue_be.auth.service;
 
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.glue.glue_be.auth.response.AuthResponseStatus;
+import org.glue.glue_be.common.exception.BaseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MailService {
 
 	@Value("${spring.mail.username}")
@@ -38,7 +42,8 @@ public class MailService {
 
 			mailSender.send(message);
 		} catch (MailSendException e) {
-			throw new MailSendException("email 코드 전송에 실패했습니다", e);
+			log.error("[이메일 발송 실패]: {}", e.getMessage(), e);
+			throw new BaseException(AuthResponseStatus.FAIL_EMAIL);
 		}
 	}
 

--- a/src/main/java/org/glue/glue_be/common/exception/ErrorValidationResult.java
+++ b/src/main/java/org/glue/glue_be/common/exception/ErrorValidationResult.java
@@ -1,0 +1,13 @@
+package org.glue.glue_be.common.exception;
+
+import java.util.*;
+
+public class ErrorValidationResult {
+    public static int ERROR_STATUS_CODE = 400;
+    public static String ERROR_MESSAGE = "유효성 검사에 실패했습니다.";
+    public final Map<String, String> validation = new HashMap<>();
+
+    public void addValidation(String fieldName, String errorMessage) {
+        this.validation.put(fieldName, errorMessage);
+    }
+}

--- a/src/main/java/org/glue/glue_be/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/glue/glue_be/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,95 @@
+package org.glue.glue_be.common.exception;
+
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.glue.glue_be.common.response.BaseResponse;
+import org.springframework.http.*;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.*;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+    // RequestBody 유효성 검증
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponse<ErrorValidationResult>> handleValidationExceptions(
+            MethodArgumentNotValidException e) {
+        ErrorValidationResult errorValidationResult = new ErrorValidationResult();
+
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            errorValidationResult.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        BaseResponse<ErrorValidationResult> response = new BaseResponse<>(
+                HttpStatus.BAD_REQUEST,
+                false,
+                ErrorValidationResult.ERROR_MESSAGE,
+                ErrorValidationResult.ERROR_STATUS_CODE,
+                errorValidationResult
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // RequestParam, PathVariable 유효성 검증
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<BaseResponse<ErrorValidationResult>> handleConstraintViolationException(
+            ConstraintViolationException e) {
+        ErrorValidationResult errorValidationResult = new ErrorValidationResult();
+
+        for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
+            String field = violation.getPropertyPath().toString();
+            String fieldName = field.contains(".") ? field.substring(field.lastIndexOf('.') + 1) : field;
+            String message = violation.getMessage();
+            errorValidationResult.addValidation(fieldName, message);
+        }
+
+        BaseResponse<ErrorValidationResult> response = new BaseResponse<>(
+                HttpStatus.BAD_REQUEST,
+                false,
+                ErrorValidationResult.ERROR_MESSAGE,
+                ErrorValidationResult.ERROR_STATUS_CODE,
+                errorValidationResult
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // RequestParam 필수값 누락
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<BaseResponse<ErrorValidationResult>> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e) {
+
+        ErrorValidationResult errorValidationResult = new ErrorValidationResult();
+
+        String name = e.getParameterName();
+        String type = e.getParameterType();
+
+        String message = String.format("'%s'(%s 타입)가 누락되었습니다.", name, type);
+        errorValidationResult.addValidation(name, message);
+
+        BaseResponse<ErrorValidationResult> response = new BaseResponse<>(
+                HttpStatus.BAD_REQUEST,
+                false,
+                ErrorValidationResult.ERROR_MESSAGE,
+                ErrorValidationResult.ERROR_STATUS_CODE,
+                errorValidationResult
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+
+    // 커스텀 예외 처리
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<BaseResponse<Void>> handleBaseExceptions(BaseException e) {
+        BaseResponse<Void> response = new BaseResponse<>(e.getStatus());
+        return ResponseEntity.status(e.getStatus().getHttpStatusCode()).body(response);
+    }
+
+
+}

--- a/src/main/java/org/glue/glue_be/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/glue/glue_be/common/exception/GlobalExceptionHandler.java
@@ -87,7 +87,7 @@ public class GlobalExceptionHandler {
     // 커스텀 예외 처리
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<BaseResponse<Void>> handleBaseExceptions(BaseException e) {
-        BaseResponse<Void> response = new BaseResponse<>(e.getStatus());
+        BaseResponse<Void> response = new BaseResponse<>(e.getStatus(), e.getMessage());
         return ResponseEntity.status(e.getStatus().getHttpStatusCode()).body(response);
     }
 

--- a/src/main/java/org/glue/glue_be/guestbook/response/GuestBookResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/guestbook/response/GuestBookResponseStatus.java
@@ -12,8 +12,9 @@ import org.springframework.http.HttpStatusCode;
 public enum GuestBookResponseStatus implements ResponseStatus {
 
     GUESTBOOK_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 방명록입니다"),
-    GUESTBOOK_NOT_AUTHOR(HttpStatus.FORBIDDEN, false, 403, "방명록 작성자만 접근할 수 있습니다.");
-
+    GUEST_BOOK_SELF_WRITE_NOT_ALLOWED(HttpStatus.FORBIDDEN, false, 403, "자신에게 방명록을 작성할 수 없습니다."),
+    GUEST_BOOK_REPLY_NOT_ALLOWED(HttpStatus.FORBIDDEN, false, 403, "방명록 댓글은 호스트만 작성할 수 있습니다."),
+    GUESTBOOK_NOT_AUTHOR(HttpStatus.FORBIDDEN, false, 403, "해당 방명록의 작성자만 접근할 수 있습니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/invitation/controller/InvitationController.java
+++ b/src/main/java/org/glue/glue_be/invitation/controller/InvitationController.java
@@ -18,14 +18,14 @@ import org.springframework.web.bind.annotation.*;
 public class InvitationController {
 
     private final InvitationService invitationService;
-    
+
     // 모임 초대장 생성 API
     @PostMapping("/meeting/{meetingId}")
     public BaseResponse<InvitationDto.Response> createMeetingInvitation(
-            @PathVariable Long meetingId, 
+            @PathVariable Long meetingId,
             @Valid @RequestBody MeetingDto.InvitationRequest request) {
         Long currentUserId = getCurrentUserId();
-        
+
         // InvitationService에 필요한 데이터 구성
         InvitationDto.CreateRequest invitationRequest = InvitationDto.CreateRequest.builder()
                 .meetingId(meetingId)
@@ -33,25 +33,25 @@ public class InvitationController {
                 .maxUses(1) // 기본값: 한 번만 사용 가능
                 .expirationHours(6) // 기본값: 6시간 유효
                 .build();
-        
+
         return new BaseResponse<>(invitationService.createInvitation(invitationRequest, currentUserId));
     }
-    
+
     // 초대장 수락 API
     @PostMapping("/accept")
-    public BaseResponse<Void> acceptInvitation(@RequestBody InvitationDto.AcceptRequest request) {
+    public BaseResponse<Void> acceptInvitation(@Valid @RequestBody InvitationDto.AcceptRequest request) {
         Long currentUserId = getCurrentUserId();
         invitationService.acceptInvitation(request.getCode(), currentUserId);
         return new BaseResponse<>();
     }
-    
+
     // 초대장 목록 조회 API
     @GetMapping
     public BaseResponse<Page<InvitationDto.Response>> getInvitations(Pageable pageable) {
         Long currentUserId = getCurrentUserId();
         return new BaseResponse<>(invitationService.getInvitations(currentUserId, pageable));
     }
-    
+
     // 현재 로그인한 사용자 ID 가져오기
     private Long getCurrentUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/org/glue/glue_be/invitation/dto/InvitationDto.java
+++ b/src/main/java/org/glue/glue_be/invitation/dto/InvitationDto.java
@@ -1,10 +1,7 @@
 package org.glue.glue_be.invitation.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import jakarta.validation.constraints.*;
+import lombok.*;
 import org.glue.glue_be.invitation.entity.Invitation;
 
 import java.time.LocalDateTime;
@@ -17,16 +14,20 @@ public class InvitationDto {
     @AllArgsConstructor
     @Builder
     public static class CreateRequest {
-        private Integer maxUses;
-        private Integer expirationHours;
+
+        @NotNull(message = "미팅 ID는 필수입니다.")
         private Long meetingId;
+
+        @Min(value = 1, message = "최대 사용 횟수는 1 이상이어야 합니다.")
+        private Integer maxUses;
+
+        @Min(value = 1, message = "만료 시간은 1시간 이상이어야 합니다.")
+        private Integer expirationHours;
+
         private Long inviteeId;
-        
-        public void setMeetingId(Long meetingId) {
-            this.meetingId = meetingId;
-        }
+
     }
-    
+
     @Getter
     @NoArgsConstructor
     public static class Response {
@@ -38,7 +39,7 @@ public class InvitationDto {
         private Integer status;
         private Long meetingId;
         private Long inviteeId;
-        
+
         public static Response from(Invitation invitation) {
             Response response = new Response();
             response.invitationId = invitation.getInvitationId();
@@ -52,10 +53,11 @@ public class InvitationDto {
             return response;
         }
     }
-    
+
     @Getter
     @NoArgsConstructor
     public static class AcceptRequest {
+        @NotBlank(message = "초대장 코드는 필수 입력값입니다.")
         private String code;
     }
 } 

--- a/src/main/java/org/glue/glue_be/invitation/response/InvitationResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/invitation/response/InvitationResponseStatus.java
@@ -1,7 +1,6 @@
 package org.glue.glue_be.invitation.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.*;
 import org.glue.glue_be.common.response.ResponseStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -9,16 +8,13 @@ import org.springframework.http.HttpStatusCode;
 @Getter
 @AllArgsConstructor
 public enum InvitationResponseStatus implements ResponseStatus {
-    
-    /**
-     * 초대장 관련 에러
-     */
-    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, false, 601, "초대장을 찾을 수 없습니다"),
-    INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, false, 602, "만료된 초대장입니다"),
-    INVITATION_FULLY_USED(HttpStatus.BAD_REQUEST, false, 603, "최대 사용 인원을 초과했습니다"),
-    INVITATION_INVALID(HttpStatus.BAD_REQUEST, false, 604, "유효하지 않은 초대장입니다"),
-    INVITATION_ALREADY_JOINED(HttpStatus.BAD_REQUEST, false, 605, "이미 참여한 미팅입니다"),
-    INVITATION_NOT_FOR_USER(HttpStatus.FORBIDDEN, false, 606, "이 초대장은 다른 사용자를 위한 것입니다");
+
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "초대장을 찾을 수 없습니다"),
+    INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, false, 400, "만료된 초대장입니다"),
+    INVITATION_FULLY_USED(HttpStatus.BAD_REQUEST, false, 400, "최대 사용 인원을 초과했습니다"),
+    INVITATION_INVALID(HttpStatus.BAD_REQUEST, false, 400, "유효하지 않은 초대장입니다"),
+    INVITATION_ALREADY_JOINED(HttpStatus.CONFLICT, false, 409, "이미 참여한 미팅입니다"),
+    INVITATION_NOT_FOR_USER(HttpStatus.FORBIDDEN, false, 403, "이 초대장은 다른 사용자를 위한 것입니다");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/invitation/service/InvitationService.java
+++ b/src/main/java/org/glue/glue_be/invitation/service/InvitationService.java
@@ -1,24 +1,19 @@
 package org.glue.glue_be.invitation.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.common.exception.BaseException;
-import org.glue.glue_be.common.response.BaseResponseStatus;
 import org.glue.glue_be.invitation.dto.InvitationDto;
 import org.glue.glue_be.invitation.entity.Invitation;
 import org.glue.glue_be.invitation.repository.InvitationRepository;
 import org.glue.glue_be.invitation.response.InvitationResponseStatus;
 import org.glue.glue_be.meeting.entity.Meeting;
-import org.glue.glue_be.meeting.entity.Participant;
-import org.glue.glue_be.meeting.repository.MeetingRepository;
-import org.glue.glue_be.meeting.repository.ParticipantRepository;
+import org.glue.glue_be.meeting.repository.*;
 import org.glue.glue_be.meeting.response.MeetingResponseStatus;
 import org.glue.glue_be.meeting.service.MeetingService;
 import org.glue.glue_be.user.entity.User;
 import org.glue.glue_be.user.repository.UserRepository;
 import org.glue.glue_be.user.response.UserResponseStatus;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,47 +29,35 @@ public class InvitationService {
     private final MeetingRepository meetingRepository;
     private final ParticipantRepository participantRepository;
     private final MeetingService meetingService;
-    
-    
+
     //미팅 초대장 생성
-     
+
     @Transactional
     public InvitationDto.Response createInvitation(InvitationDto.CreateRequest request, Long creatorId) {
         // 사용자 조회
         User creator = userRepository.findById(creatorId)
                 .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
-        
-        // 미팅 존재 확인 
-        if (request.getMeetingId() == null) {
-            throw new BaseException(BaseResponseStatus.INVALID_INPUT_VALUE, "미팅 ID는 필수입니다");
-        }
-        
+
         Meeting meeting = meetingRepository.findById(request.getMeetingId())
                 .orElseThrow(() -> new BaseException(MeetingResponseStatus.MEETING_NOT_FOUND));
-        
+
         // 사용자가 해당 모임의 참가자인지 확인
         if (!participantRepository.existsByUserAndMeeting(creator, meeting)) {
             throw new BaseException(MeetingResponseStatus.NOT_JOINED);
         }
-        
+
         // inviteeId가 있는 경우 해당 사용자가 유효한지 확인
         if (request.getInviteeId() != null) {
             userRepository.findById(request.getInviteeId())
                     .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND, "초대할 사용자를 찾을 수 없습니다"));
         }
-        
+
         String code = generateUniqueCode();
-        
+
         // expiresAt 계산
-        LocalDateTime expiresAt = LocalDateTime.now();
-        
-        if (request.getExpirationHours() != null && request.getExpirationHours() > 0) {
-            expiresAt = expiresAt.plusHours(request.getExpirationHours());
-        } else {
-            // 기본값: 6시간으로 설정
-            expiresAt = expiresAt.plusHours(6);
-        }
-        
+        LocalDateTime expiresAt = LocalDateTime.now()
+                .plusHours(request.getExpirationHours() != null ? request.getExpirationHours() : 6);
+
         Invitation invitation = Invitation.builder()
                 .code(code)
                 .expiresAt(expiresAt)
@@ -83,10 +66,10 @@ public class InvitationService {
                 .meeting(meeting)  // meeting 객체를 직접 설정
                 .inviteeId(request.getInviteeId())
                 .build();
-        
+
         return InvitationDto.Response.from(invitationRepository.save(invitation));
     }
-    
+
     /**
      * 미팅 초대장 수락
      */
@@ -95,11 +78,11 @@ public class InvitationService {
         // 비관적 락을 사용하여 동시성 제어
         Invitation invitation = invitationRepository.findByCodeWithLock(code)
                 .orElseThrow(() -> new BaseException(InvitationResponseStatus.INVITATION_NOT_FOUND));
-        
+
         // 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
-        
+
         // 초대장 유효성 검사
         if (!invitation.isValid()) {
             if (LocalDateTime.now().isAfter(invitation.getExpiresAt())) {
@@ -111,43 +94,33 @@ public class InvitationService {
                 throw new BaseException(InvitationResponseStatus.INVITATION_INVALID);
             }
         }
-        
+
         // 특정 사용자를 위한 초대장인 경우, 해당 사용자만 사용 가능하도록 체크
         if (!invitation.canBeUsedBy(userId)) {
             throw new BaseException(InvitationResponseStatus.INVITATION_NOT_FOR_USER);
         }
-        
+
         // 초대장 사용 횟수 증가
         invitation.incrementUsedCount();
-        
+
         // 미팅 처리
         Meeting meeting = invitation.getMeeting();
         if (meeting == null) {
             throw new BaseException(MeetingResponseStatus.MEETING_NOT_FOUND);
         }
-        
+
         // 이미 참여한 사용자인지 체크
         if (participantRepository.existsByUserAndMeeting(user, meeting)) {
             throw new BaseException(InvitationResponseStatus.INVITATION_ALREADY_JOINED);
         }
-        
-        try {
-            // MeetingService를 통해 참가자 추가
-            meetingService.joinMeeting(meeting.getMeetingId(), userId);
-            
-            // 미팅을 활성화 상태로 변경
-            meeting.activateMeeting();
-        } catch (BaseException e) {
-            // MeetingService에서 발생한 예외를 InvitationResponseStatus로 변환
-            if (e.getStatus().equals(MeetingResponseStatus.MEETING_FULL)) {
-                throw new BaseException(MeetingResponseStatus.MEETING_FULL);
-            } else if (e.getStatus().equals(MeetingResponseStatus.ALREADY_JOINED)) {
-                throw new BaseException(InvitationResponseStatus.INVITATION_ALREADY_JOINED);
-            }
-            throw e;
-        }
+
+        // MeetingService를 통해 참가자 추가
+        meetingService.joinMeeting(meeting.getMeetingId(), userId);
+
+        // 미팅을 활성화 상태로 변경
+        meeting.activateMeeting();
     }
-    
+
     /**
      * 초대장 목록 조회
      */
@@ -156,11 +129,11 @@ public class InvitationService {
         // 사용자 조회
         User creator = userRepository.findById(creatorId)
                 .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
-        
+
         return invitationRepository.findByCreator(creator, pageable)
                 .map(InvitationDto.Response::from);
     }
-    
+
     /**
      * 고유한 초대 코드 생성
      */

--- a/src/main/java/org/glue/glue_be/meeting/dto/MeetingDto.java
+++ b/src/main/java/org/glue/glue_be/meeting/dto/MeetingDto.java
@@ -1,5 +1,7 @@
 package org.glue.glue_be.meeting.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -27,6 +29,8 @@ public class MeetingDto {
         private String meetingTitle;
 
         @NotNull(message = "모임 시간은 필수입니다")
+        @Future(message = "모임 시간은 현재 시간 이후여야 합니다")
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime meetingTime;
 
         @NotBlank(message = "모임 장소는 필수입니다")

--- a/src/main/java/org/glue/glue_be/meeting/response/MeetingResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/meeting/response/MeetingResponseStatus.java
@@ -9,18 +9,15 @@ import org.springframework.http.HttpStatusCode;
 @Getter
 @AllArgsConstructor
 public enum MeetingResponseStatus implements ResponseStatus {
-    
-    /**
-     * 모임 관련 에러
-     */
-    MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, false, 551, "존재하지 않는 모임입니다"),
-    MEETING_FULL(HttpStatus.BAD_REQUEST, false, 552, "모임이 꽉 찼습니다"),
-    MIN_OVER_MAX(HttpStatus.BAD_REQUEST, false, 553, "최소 인원이 최대 인원보다 클 수 없습니다"),
-    INVALID_MEETING_TIME(HttpStatus.BAD_REQUEST, false, 554, "모임 시간은 현재 시간 이후여야 합니다"),
-    ALREADY_JOINED(HttpStatus.BAD_REQUEST, false, 555, "이미 모임에 참여 중입니다"),
-    NON_PARTICIPANT_INVITATION(HttpStatus.FORBIDDEN, false, 556, "모임 참가자만 초대장을 생성할 수 있습니다"),
-    NOT_HOST_PERMISSION(HttpStatus.FORBIDDEN, false, 557, "모임 주최자만 이 작업을 수행할 수 있습니다"),
-    NOT_JOINED(HttpStatus.FORBIDDEN, false, 558, "모임에 참여하지 않은 사용자입니다");
+
+    MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 모임입니다"),
+    MEETING_FULL(HttpStatus.BAD_REQUEST, false, 400, "모임이 꽉 찼습니다"),
+    MIN_OVER_MAX(HttpStatus.BAD_REQUEST, false, 400, "최소 인원이 최대 인원보다 클 수 없습니다"),
+    INVALID_MEETING_TIME(HttpStatus.BAD_REQUEST, false, 400, "모임 시간은 현재 시간 이후여야 합니다"),
+    ALREADY_JOINED(HttpStatus.CONFLICT, false, 409, "이미 모임에 참여 중입니다"),
+    NON_PARTICIPANT_INVITATION(HttpStatus.FORBIDDEN, false, 403, "모임 참가자만 초대장을 생성할 수 있습니다"),
+    NOT_HOST_PERMISSION(HttpStatus.FORBIDDEN, false, 403, "모임 주최자만 이 작업을 수행할 수 있습니다"),
+    NOT_JOINED(HttpStatus.FORBIDDEN, false, 403, "모임에 참여하지 않은 사용자입니다");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/meeting/service/MeetingService.java
+++ b/src/main/java/org/glue/glue_be/meeting/service/MeetingService.java
@@ -2,12 +2,9 @@ package org.glue.glue_be.meeting.service;
 
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.common.exception.BaseException;
-import org.glue.glue_be.common.response.BaseResponseStatus;
 import org.glue.glue_be.meeting.dto.MeetingDto;
-import org.glue.glue_be.meeting.entity.Meeting;
-import org.glue.glue_be.meeting.entity.Participant;
-import org.glue.glue_be.meeting.repository.MeetingRepository;
-import org.glue.glue_be.meeting.repository.ParticipantRepository;
+import org.glue.glue_be.meeting.entity.*;
+import org.glue.glue_be.meeting.repository.*;
 import org.glue.glue_be.meeting.response.MeetingResponseStatus;
 import org.glue.glue_be.user.entity.User;
 import org.glue.glue_be.user.repository.UserRepository;
@@ -15,7 +12,6 @@ import org.glue.glue_be.user.response.UserResponseStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -33,10 +29,6 @@ public class MeetingService {
         // 유효성 검증
         if (request.getMinPpl() > request.getMaxPpl()) {
             throw new BaseException(MeetingResponseStatus.MIN_OVER_MAX);
-        }
-
-        if (request.getMeetingTime().isBefore(LocalDateTime.now())) {
-            throw new BaseException(MeetingResponseStatus.INVALID_MEETING_TIME);
         }
 
         // 사용자 조회

--- a/src/main/java/org/glue/glue_be/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/glue/glue_be/post/dto/request/CreatePostRequest.java
@@ -1,6 +1,7 @@
 package org.glue.glue_be.post.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -28,6 +29,7 @@ public class CreatePostRequest {
 
 		@NotNull(message = "모임일시는 필수값입니다")
 		@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+		@Future(message = "모임 시간은 현재 시간 이후여야 합니다")
 		private LocalDateTime meetingTime;
 
 		private Double meetingPlaceLatitude;

--- a/src/main/java/org/glue/glue_be/post/response/PostResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/post/response/PostResponseStatus.java
@@ -11,14 +11,9 @@ import org.springframework.http.HttpStatusCode;
 @AllArgsConstructor
 public enum PostResponseStatus implements ResponseStatus {
 
-	/**
-	 * 게시글 관련 에러
-	 */
-	POST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 600, "존재하지 않는 게시글입니다"),
-	POST_CANNOT_BUMP_YET(HttpStatus.NOT_EXTENDED, false, 601 , "이전 끌올에서 3일이 지나야 끌올할 수 있습니다." ),
-	POST_NOT_AUTHOR(HttpStatus.FORBIDDEN, false, 602, "게시글 작성자만 접근할 수 있습니다."),
-
-	;
+	POST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 게시글입니다"),
+	POST_CANNOT_BUMP_YET(HttpStatus.NOT_EXTENDED, false, 400 , "이전 끌올에서 3일이 지나야 끌올할 수 있습니다." ),
+	POST_NOT_AUTHOR(HttpStatus.FORBIDDEN, false, 403, "게시글 작성자만 접근할 수 있습니다.");
 
 	private final HttpStatusCode httpStatusCode;
 	private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/user/response/UserResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/user/response/UserResponseStatus.java
@@ -1,22 +1,15 @@
 package org.glue.glue_be.user.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.*;
 import org.glue.glue_be.common.response.ResponseStatus;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
+import org.springframework.http.*;
 
 @Getter
 @AllArgsConstructor
 public enum UserResponseStatus implements ResponseStatus {
-    
-    /**
-     * 사용자 관련 에러
-     */
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 501, "존재하지 않는 사용자입니다"),
-    ALREADY_EXISTS(HttpStatus.CONFLICT, false, 502, "이미 사용자가 존재합니다."),
 
-    ;
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 사용자입니다"),
+    ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 사용자가 존재합니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/util/fcm/controller/FcmController.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/controller/FcmController.java
@@ -1,5 +1,6 @@
 package org.glue.glue_be.util.fcm.controller;
 
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.glue.glue_be.common.response.BaseResponse;
 import org.glue.glue_be.util.fcm.dto.FcmSendDto;
@@ -22,17 +23,16 @@ public class FcmController {
 
     // 단일 기기로 fcm 발송
     @PostMapping("/single")
-    public BaseResponse<Void> sendSingle(@RequestBody FcmSendDto dto) {
+    public BaseResponse<Void> sendSingle(@RequestBody @Valid FcmSendDto dto) {
         fcmService.sendMessage(dto);
-        return new BaseResponse<>(FcmResponseStatus.FCM_SEND_SUCCESS);
+        return new BaseResponse<>();
     }
 
     // 여러 기기로 fcm 발송
     @PostMapping("/multi")
-    public BaseResponse<Void> sendMulti(@RequestBody MultiFcmSendDto dto) {
+    public BaseResponse<Void> sendMulti(@RequestBody @Valid MultiFcmSendDto dto) {
         fcmService.sendMultiMessage(dto);
-        return new BaseResponse<>(FcmResponseStatus.FCM_MULTICAST_SUCCESS);
+        return new BaseResponse<>();
     }
-
 
 }

--- a/src/main/java/org/glue/glue_be/util/fcm/service/FcmService.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/service/FcmService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class FcmService {
+
     public void sendMessage(FcmSendDto fcmSendDto) {
         Message message = Message.builder()
                 .setNotification(Notification.builder()
@@ -25,11 +26,16 @@ public class FcmService {
                 .build();
 
         try {
-            log.info("FCM 단일 전송 성공");
             FirebaseMessaging.getInstance().send(message);
         } catch (FirebaseMessagingException e) {
-            log.error("FCM 단일 전송 실패", e);
-            throw new BaseException(FcmResponseStatus.FCM_SEND_ERROR, e.getMessage());
+            log.error("[FCM 단일 전송 실패] token: {}, title: {}, body: {}, message: {}",
+                    fcmSendDto.getToken(),
+                    fcmSendDto.getTitle(),
+                    fcmSendDto.getBody(),
+                    e.getMessage(),
+                    e
+            );
+            throw new BaseException(FcmResponseStatus.FCM_SEND_ERROR, "유효하지 않은 FCM 토큰입니다.");
         }
     }
 
@@ -43,13 +49,16 @@ public class FcmService {
                 .build();
 
         try {
-            log.info("FCM 단체 전송 성공");
             FirebaseMessaging.getInstance().sendMulticast(message);
         } catch (FirebaseMessagingException e) {
-            log.error("FCM 단체 전송 실패", e);
-            throw new BaseException(FcmResponseStatus.FCM_MULTICAST_ERROR, e.getMessage());
+            log.error("[FCM 단체 전송 실패] tokens: {}, title: {}, body: {}, message: {}",
+                    multiFcmSendDto.getTokens(),
+                    multiFcmSendDto.getTitle(),
+                    multiFcmSendDto.getBody(),
+                    e.getMessage(),
+                    e
+            );
+            throw new BaseException(FcmResponseStatus.FCM_MULTICAST_ERROR, "FCM 다중 전송에 실패했습니다.");
         }
     }
-
-
 }


### PR DESCRIPTION
## ✅ 주요 변경 사항

- `GlobalExceptionHandler` 구현  
  - `MethodArgumentNotValidException` (RequestBody 유효성 검사 실패)  
  - `ConstraintViolationException` (RequestParam, PathVariable 유효성 검사 실패)  
  - `MissingServletRequestParameterException` (요청 파라미터 누락)  
  - `BaseException` 처리

- `ErrorValidationResult` 도입  
  - 유효성 검사 실패 응답을 통일된 JSON 포맷으로 반환  
  - 클라이언트에서 일관된 에러 메시지 처리 가능

- 도메인별 예외 메시지 및 상태 코드 정비  
  - Auth, FCM, Invitation, Meeting, Post, GuestBook 등 전체 도메인 대상  
  - 상태 코드 정렬 및 메시지 표현 통일

- 인증 / 소셜 로그인 / 이메일 / FCM / 초대장 전반 예외 처리 개선  
  - `RuntimeException` 제거 → `BaseException` 기반으로 통합  
  - 외부 API 호출 실패 시 log 상세 기록 및 사용자 응답 명확화


## 🎯 목적

- 예외 응답 포맷의 **일관성 확보**
- 클라이언트 및 프론트엔드에서 **예외 상황을 명확히 인식 가능**
- 예외 메시지와 코드의 **유지보수 편의성 향상**


---

## 🛠️ 사용 가이드 (팀원 안내)

> **이제부터 `RuntimeException` 사용 ❌ 금지입니다.**  
> 모든 커스텀 예외는 `BaseException`을 상속하거나 그대로 사용해주세요.  (`ResponseStatus`를 사용하면 됩니다.)
> 그래야 예외가 전역 핸들러에서 잘 잡히고 응답 포맷도 유지됩니다.

---
## 📷 결과

기존에는 아래처럼 **길고 불필요한 예외 메시지**가 노출되었습니다:

<br>

<img src="https://github.com/user-attachments/assets/12a4c398-8579-4050-9d86-758cbcdd85d9" width="600" />

<br><br>

이제는 아래처럼 **간결하고 일관된 구조의 응답 포맷**으로 정리됩니다:

<br>

<img src="https://github.com/user-attachments/assets/6328eedc-deab-49f7-8c67-6f66511085bf" width="600" />




closes #71 
