### PR TITLE
hotfix: 참여자 디엠 목록 조회 기준 수정

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
@@ -15,10 +15,10 @@ import java.util.Optional;
 public interface DmUserChatroomRepository extends JpaRepository<DmUserChatroom, Long> {
     List<DmUserChatroom> findByDmChatRoom(DmChatRoom dmChatRoom);
 
-    @Query("SELECT uc.user.userId FROM DmUserChatroom uc WHERE uc.dmChatRoom.id = :dmChatRoomId")
-    List<Long> findUserIdsByDmChatRoomId(@Param("dmChatRoomId") Long dmChatRoomId);
-
     void deleteByDmChatRoomAndUser(DmChatRoom dmChatRoom, User user);
 
     Optional<DmUserChatroom> findByDmChatRoomAndUser(DmChatRoom dmChatRoom, User sender);
+
+    @Query("SELECT ducr.dmChatRoom FROM DmUserChatroom ducr WHERE ducr.user.userId = :userId")
+    List<DmChatRoom> findDmChatRoomsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -208,17 +208,13 @@ public class DmChatService extends CommonChatService {
                 userId,
                 this::getUserById,
                 user -> {
-                    List<Participant> participations = participantRepository.findByUser_UserId(user.getUserId());
+                    // 참가한 DM 채팅방들을 직접 조회
+                    List<DmChatRoom> participatedDmChatRooms = dmUserChatroomRepository.findDmChatRoomsByUserId(userId);
 
-                    // 1. 참가한 Meeting 목록 추출
-                    List<Meeting> participatedMeetings = participations.stream()
-                            .map(Participant::getMeeting)
-                            // 2. 내가 호스트가 아닌 미팅만 필터링
-                            .filter(meeting -> !meeting.getHost().getUserId().equals(userId))
+                    // 내가 호스트가 아닌 미팅의 DM 채팅방만 필터링
+                    return participatedDmChatRooms.stream()
+                            .filter(dmChatRoom -> !dmChatRoom.getMeeting().getHost().getUserId().equals(userId))
                             .collect(Collectors.toList());
-
-                    // 3. 해당 미팅의 DM 채팅방 조회
-                    return dmChatRoomRepository.findByMeetingIn(participatedMeetings);
                 },
                 this::convertToChatRoomResponses
         );


### PR DESCRIPTION
- 기존에는 사용자들이 참여한 모임 명단을 나타내는 participants 테이블을 기반으로, 내가 참여자인 디엠 목록을 나열했었습니다.
- 하지만 디엠 기능은 모임에 참여하기 전의 것이므로 단순히 dm_userchatroom 테이블을 참조하도록 수정했습니다.