### PR TITLE
feat: 메인 캐러셀 기능 추가

### DIFF
--- a/src/main/java/org/glue/glue_be/aws/config/S3Config.java
+++ b/src/main/java/org/glue/glue_be/aws/config/S3Config.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 
@@ -23,16 +24,27 @@ public class S3Config {
 	private Region region;
 
 
-	// 우리 서비스 AWS 인증 객체
-	@Bean
-	public S3Presigner s3Presigner() {
-		AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
-			AwsBasicCredentials.create(accessKey, secretKey));
-
-		return S3Presigner.builder()
-			.region(region)
-			.credentialsProvider(credentialsProvider)
-			.build();
+	// AWS 인증 객체 생성 메서드
+	private AwsCredentialsProvider getCredentialsProvider() {
+		return StaticCredentialsProvider.create(
+				AwsBasicCredentials.create(accessKey, secretKey));
 	}
 
+	// 추가용
+	@Bean
+	public S3Presigner s3Presigner() {
+		return S3Presigner.builder()
+				.region(region)
+				.credentialsProvider(getCredentialsProvider())
+				.build();
+	}
+
+	// 삭제용
+	@Bean
+	public S3Client s3Client() {
+		return S3Client.builder()
+				.region(region)
+				.credentialsProvider(getCredentialsProvider())
+				.build();
+	}
 }

--- a/src/main/java/org/glue/glue_be/main/controller/MainController.java
+++ b/src/main/java/org/glue/glue_be/main/controller/MainController.java
@@ -1,0 +1,62 @@
+package org.glue.glue_be.main.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.main.dto.request.CarouselDeployVersionRequest;
+import org.glue.glue_be.main.dto.request.MainCarouselCreateRequest;
+import org.glue.glue_be.main.dto.response.*;
+import org.glue.glue_be.main.service.MainService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/main/carousel")
+@RequiredArgsConstructor
+public class MainController {
+
+    private final MainService mainService;
+
+    // 조회
+    @GetMapping
+    public ResponseEntity<MainCarouselResponse> getCarouselImages(
+            @RequestParam(required = false) String version) {
+        MainCarouselResponse response = mainService.getCarouselImages(version);
+        return ResponseEntity.ok(response);
+    }
+
+    // TODO: 관리자용 api들 관리자만 접근 가능하도록
+    // 모든 버전 목록 조회 (관리자용)
+    @GetMapping("/versions")
+    public ResponseEntity<CarouselVersionResponse> getAllVersions() {
+        CarouselVersionResponse response = mainService.getAllVersions();
+        return ResponseEntity.ok(response);
+    }
+
+    // 현재 배포 버전 조회 (관리자용)
+    @GetMapping("/deploy-version")
+    public String getCurrentDeployVersion() {
+        return mainService.getCurrentDeployVersion();
+    }
+
+    // 배포 버전 설정 (관리자용)
+    @PostMapping("/deploy-version")
+    public ResponseEntity<CarouselDeployVersionResponse> setDeployVersion(
+            @RequestBody CarouselDeployVersionRequest request) {
+        CarouselDeployVersionResponse response = mainService.setDeployVersion(request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 등록용 Presigned URL 생성 (관리자용)
+    @PostMapping("/presigned-url")
+    public ResponseEntity<CarouselPresignedUrlResponse> createPresignedUrlForUpload(
+            @RequestBody MainCarouselCreateRequest request) {
+        CarouselPresignedUrlResponse response = mainService.createPresignedUrlForUpload(request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 버전별 일괄 삭제 (관리자용)
+    @DeleteMapping("/version/{version}")
+    public ResponseEntity<CarouselBulkDeleteResponse> deleteCarouselsByVersion(@PathVariable String version) {
+        CarouselBulkDeleteResponse response = mainService.deleteCarouselsByVersion(version);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/glue/glue_be/main/dto/CarouselImageDto.java
+++ b/src/main/java/org/glue/glue_be/main/dto/CarouselImageDto.java
@@ -1,0 +1,19 @@
+package org.glue.glue_be.main.dto;
+
+import org.glue.glue_be.main.entity.MainCarousel;
+
+public record CarouselImageDto(
+        Long id,
+        String imageUrl,
+        Integer displayOrder,
+        String description
+) {
+    public static CarouselImageDto fromEntity(MainCarousel carousel) {
+        return new CarouselImageDto(
+                carousel.getId(),
+                carousel.getImageUrl(),
+                carousel.getDisplayOrder(),
+                carousel.getDescription()
+        );
+    }
+}

--- a/src/main/java/org/glue/glue_be/main/dto/request/CarouselDeployVersionRequest.java
+++ b/src/main/java/org/glue/glue_be/main/dto/request/CarouselDeployVersionRequest.java
@@ -1,0 +1,30 @@
+package org.glue.glue_be.main.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.glue.glue_be.main.entity.CarouselDeployVersion;
+
+public record CarouselDeployVersionRequest(
+
+        @NotBlank(message = "버전은 필수값입니다.")
+        @Size(max = 50, message = "버전은 50글자보다 이하여야 합니다.")
+        String version,
+
+        @Size(max = 200, message = "설명은 200글자 이하여야 합니다.")
+        String description
+) {
+
+    public CarouselDeployVersion toEntity() {
+        return CarouselDeployVersion.builder()
+                .version(this.version)
+                .description(this.description)
+                .isActive(true)
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("CarouselDeployVersionRequest{version='%s', description='%s'}",
+                version, description);
+    }
+}

--- a/src/main/java/org/glue/glue_be/main/dto/request/MainCarouselCreateRequest.java
+++ b/src/main/java/org/glue/glue_be/main/dto/request/MainCarouselCreateRequest.java
@@ -1,0 +1,18 @@
+package org.glue.glue_be.main.dto.request;
+
+import org.glue.glue_be.main.entity.MainCarousel;
+
+public record MainCarouselCreateRequest(
+        String version,
+        String fileName,
+        String description
+) {
+    public MainCarousel toEntity(String imageUrl, Integer displayOrder) {
+        return MainCarousel.builder()
+                .imageUrl(imageUrl)
+                .version(this.version)
+                .displayOrder(displayOrder)
+                .description(this.description)
+                .build();
+    }
+}

--- a/src/main/java/org/glue/glue_be/main/dto/response/CarouselBulkDeleteResponse.java
+++ b/src/main/java/org/glue/glue_be/main/dto/response/CarouselBulkDeleteResponse.java
@@ -1,0 +1,8 @@
+package org.glue.glue_be.main.dto.response;
+
+public record CarouselBulkDeleteResponse(
+        String version,
+        Integer totalCount,
+        Integer successCount,
+        Integer failedCount
+) { }

--- a/src/main/java/org/glue/glue_be/main/dto/response/CarouselDeployVersionResponse.java
+++ b/src/main/java/org/glue/glue_be/main/dto/response/CarouselDeployVersionResponse.java
@@ -1,0 +1,28 @@
+package org.glue.glue_be.main.dto.response;
+
+import org.glue.glue_be.main.entity.CarouselDeployVersion;
+
+public record CarouselDeployVersionResponse(
+        Long id,
+        String version,
+        Boolean isActive,
+        String description
+) {
+
+    public static CarouselDeployVersionResponse fromEntity(CarouselDeployVersion entity) {
+        return new CarouselDeployVersionResponse(
+                entity.getId(),
+                entity.getVersion(),
+                entity.getIsActive(),
+                entity.getDescription()
+        );
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "CarouselDeployVersionResponse{id=%d, version='%s', isActive=%s, description='%s'}",
+                id, version, isActive, description
+        );
+    }
+}

--- a/src/main/java/org/glue/glue_be/main/dto/response/CarouselPresignedUrlResponse.java
+++ b/src/main/java/org/glue/glue_be/main/dto/response/CarouselPresignedUrlResponse.java
@@ -2,14 +2,12 @@ package org.glue.glue_be.main.dto.response;
 
 import org.glue.glue_be.aws.dto.GetPresignedUrlResponse;
 
-// Presigned URL 응답 DTO (기존 GetPresignedUrlResponse 활용)
 public record CarouselPresignedUrlResponse(
         String presignedUrl,
         String publicUrl,
         String fileName,
         Long carouselId
 ) {
-    // 기존 GetPresignedUrlResponse에서 변환하는 정적 메서드
     public static CarouselPresignedUrlResponse fromEntity(GetPresignedUrlResponse response, String fileName, Long carouselId) {
         return new CarouselPresignedUrlResponse(
                 response.getPresignedUrl(),

--- a/src/main/java/org/glue/glue_be/main/dto/response/CarouselPresignedUrlResponse.java
+++ b/src/main/java/org/glue/glue_be/main/dto/response/CarouselPresignedUrlResponse.java
@@ -1,0 +1,21 @@
+package org.glue.glue_be.main.dto.response;
+
+import org.glue.glue_be.aws.dto.GetPresignedUrlResponse;
+
+// Presigned URL 응답 DTO (기존 GetPresignedUrlResponse 활용)
+public record CarouselPresignedUrlResponse(
+        String presignedUrl,
+        String publicUrl,
+        String fileName,
+        Long carouselId
+) {
+    // 기존 GetPresignedUrlResponse에서 변환하는 정적 메서드
+    public static CarouselPresignedUrlResponse fromEntity(GetPresignedUrlResponse response, String fileName, Long carouselId) {
+        return new CarouselPresignedUrlResponse(
+                response.getPresignedUrl(),
+                response.getPublicUrl(),
+                fileName,
+                carouselId
+        );
+    }
+}

--- a/src/main/java/org/glue/glue_be/main/dto/response/CarouselVersionResponse.java
+++ b/src/main/java/org/glue/glue_be/main/dto/response/CarouselVersionResponse.java
@@ -1,0 +1,14 @@
+package org.glue.glue_be.main.dto.response;
+
+import java.util.List;
+
+public record CarouselVersionResponse(
+        List<String> versions,
+        Integer totalCount
+) {
+
+    public boolean isEmpty() {
+        return versions == null || versions.isEmpty();
+    }
+
+}

--- a/src/main/java/org/glue/glue_be/main/dto/response/MainCarouselResponse.java
+++ b/src/main/java/org/glue/glue_be/main/dto/response/MainCarouselResponse.java
@@ -1,0 +1,12 @@
+package org.glue.glue_be.main.dto.response;
+
+import org.glue.glue_be.main.dto.CarouselImageDto;
+
+import java.util.List;
+
+public record MainCarouselResponse(
+        String version,
+        List<CarouselImageDto> images,
+        Integer totalCount
+) {}
+

--- a/src/main/java/org/glue/glue_be/main/entity/CarouselDeployVersion.java
+++ b/src/main/java/org/glue/glue_be/main/entity/CarouselDeployVersion.java
@@ -1,0 +1,49 @@
+package org.glue.glue_be.main.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.glue.glue_be.common.BaseEntity;
+
+@Entity
+@Table(name = "carousel_deploy_version")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CarouselDeployVersion extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "version", nullable = false, unique = true)
+    private String version;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Column(name = "description")
+    private String description;
+
+    @Builder
+    private CarouselDeployVersion(String version, Boolean isActive, String description) {
+        this.version = version;
+        this.isActive = isActive != null ? isActive : true;
+        this.description = description;
+    }
+
+    public void updateVersion(String version, String description) {
+        if (version != null) this.version = version;
+        if (description != null) this.description = description;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+}

--- a/src/main/java/org/glue/glue_be/main/entity/MainCarousel.java
+++ b/src/main/java/org/glue/glue_be/main/entity/MainCarousel.java
@@ -1,0 +1,45 @@
+package org.glue.glue_be.main.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.glue.glue_be.common.BaseEntity;
+
+@Entity
+@Table(name = "main_carousel")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MainCarousel extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "version", nullable = false)
+    private String version;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+
+    @Column(name = "description")
+    private String description;
+
+    @Builder
+    private MainCarousel(String imageUrl, String version, Integer displayOrder, String description) {
+        this.imageUrl = imageUrl;
+        this.version = version;
+        this.displayOrder = displayOrder;
+        this.description = description;
+    }
+
+    public void updateCarousel(String imageUrl, String description) {
+        if (imageUrl != null) this.imageUrl = imageUrl;
+        if (description != null) this.description = description;
+    }
+}

--- a/src/main/java/org/glue/glue_be/main/entity/MainCarousel.java
+++ b/src/main/java/org/glue/glue_be/main/entity/MainCarousel.java
@@ -37,9 +37,4 @@ public class MainCarousel extends BaseEntity {
         this.displayOrder = displayOrder;
         this.description = description;
     }
-
-    public void updateCarousel(String imageUrl, String description) {
-        if (imageUrl != null) this.imageUrl = imageUrl;
-        if (description != null) this.description = description;
-    }
 }

--- a/src/main/java/org/glue/glue_be/main/repository/CarouselDeployVersionRepository.java
+++ b/src/main/java/org/glue/glue_be/main/repository/CarouselDeployVersionRepository.java
@@ -18,25 +18,4 @@ public interface CarouselDeployVersionRepository extends JpaRepository<CarouselD
 
     Optional<CarouselDeployVersion> findByVersion(String version);
 
-    @Query("SELECT COUNT(c) > 0 FROM CarouselDeployVersion c WHERE c.isActive = true")
-    boolean existsActiveVersion();
-
-    @Modifying
-    @Transactional
-    @Query("UPDATE CarouselDeployVersion c SET c.isActive = false WHERE c.isActive = true")
-    void deactivateAllVersions();
-
-    @Modifying
-    @Transactional
-    @Query("UPDATE CarouselDeployVersion c SET c.isActive = false WHERE c.isActive = true AND c.version != :version")
-    void deactivateAllVersionsExcept(@Param("version") String version);
-
-    List<CarouselDeployVersion> findAllByOrderByUpdatedAtDesc();
-
-    List<CarouselDeployVersion> findByIsActiveOrderByUpdatedAtDesc(Boolean isActive);
-
-    boolean existsByVersion(String version);
-
-    @Query("SELECT c FROM CarouselDeployVersion c WHERE c.version LIKE %:pattern% ORDER BY c.version")
-    List<CarouselDeployVersion> findByVersionContaining(@Param("pattern") String pattern);
 }

--- a/src/main/java/org/glue/glue_be/main/repository/CarouselDeployVersionRepository.java
+++ b/src/main/java/org/glue/glue_be/main/repository/CarouselDeployVersionRepository.java
@@ -1,0 +1,42 @@
+package org.glue.glue_be.main.repository;
+
+import org.glue.glue_be.main.entity.CarouselDeployVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CarouselDeployVersionRepository extends JpaRepository<CarouselDeployVersion, Long> {
+
+    Optional<CarouselDeployVersion> findByIsActiveTrue();
+
+    Optional<CarouselDeployVersion> findByVersion(String version);
+
+    @Query("SELECT COUNT(c) > 0 FROM CarouselDeployVersion c WHERE c.isActive = true")
+    boolean existsActiveVersion();
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE CarouselDeployVersion c SET c.isActive = false WHERE c.isActive = true")
+    void deactivateAllVersions();
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE CarouselDeployVersion c SET c.isActive = false WHERE c.isActive = true AND c.version != :version")
+    void deactivateAllVersionsExcept(@Param("version") String version);
+
+    List<CarouselDeployVersion> findAllByOrderByUpdatedAtDesc();
+
+    List<CarouselDeployVersion> findByIsActiveOrderByUpdatedAtDesc(Boolean isActive);
+
+    boolean existsByVersion(String version);
+
+    @Query("SELECT c FROM CarouselDeployVersion c WHERE c.version LIKE %:pattern% ORDER BY c.version")
+    List<CarouselDeployVersion> findByVersionContaining(@Param("pattern") String pattern);
+}

--- a/src/main/java/org/glue/glue_be/main/repository/MainCarouselRepository.java
+++ b/src/main/java/org/glue/glue_be/main/repository/MainCarouselRepository.java
@@ -1,0 +1,21 @@
+package org.glue.glue_be.main.repository;
+
+import org.glue.glue_be.main.entity.MainCarousel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface MainCarouselRepository extends JpaRepository<MainCarousel, Long> {
+
+    List<MainCarousel> findByVersionOrderByDisplayOrder(String version);
+
+    @Query("SELECT MAX(m.displayOrder) FROM MainCarousel m WHERE m.version = :version")
+    Integer findMaxDisplayOrderByVersion(@Param("version") String version);
+
+    // 모든 버전 목록 조회 (중복 제거)
+    @Query("SELECT DISTINCT m.version FROM MainCarousel m ORDER BY m.version")
+    List<String> findAllVersions();
+}

--- a/src/main/java/org/glue/glue_be/main/response/MainResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/main/response/MainResponseStatus.java
@@ -1,0 +1,34 @@
+package org.glue.glue_be.main.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.glue.glue_be.common.response.ResponseStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+
+@Getter
+@AllArgsConstructor
+public enum MainResponseStatus implements ResponseStatus {
+
+    // 버전 관련
+    VERSION_REQUIRED(HttpStatus.BAD_REQUEST, false, 400, "버전 입력이 필수입니다."),
+    NO_ACTIVE_DEPLOY_VERSION(HttpStatus.NOT_FOUND, false, 404, "활성화된 배포 버전이 없습니다. 먼저 배포 버전을 설정해주세요."),
+    VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 버전을 찾을 수 없습니다."),
+    NO_CAROUSELS_FOR_VERSION(HttpStatus.BAD_REQUEST, false, 400, "해당 버전에 등록된 캐러셀이 없습니다."),
+
+    // 파일 관련
+    FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, false, 400, "파일명 입력이 필수입니다."),
+    INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, false, 400, "유효하지 않은 파일명입니다."),
+
+    // 캐러셀 관련
+    CAROUSEL_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "캐러셀을 찾을 수 없습니다."),
+
+    // 일반 에러
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/org/glue/glue_be/main/service/MainService.java
+++ b/src/main/java/org/glue/glue_be/main/service/MainService.java
@@ -1,0 +1,201 @@
+package org.glue.glue_be.main.service;
+
+import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.aws.service.FileService;
+import org.glue.glue_be.aws.dto.GetPresignedUrlResponse;
+import org.glue.glue_be.common.exception.BaseException;
+import org.glue.glue_be.main.dto.*;
+import org.glue.glue_be.main.dto.request.CarouselDeployVersionRequest;
+import org.glue.glue_be.main.dto.request.MainCarouselCreateRequest;
+import org.glue.glue_be.main.dto.response.*;
+import org.glue.glue_be.main.entity.MainCarousel;
+import org.glue.glue_be.main.entity.CarouselDeployVersion;
+import org.glue.glue_be.main.repository.MainCarouselRepository;
+import org.glue.glue_be.main.repository.CarouselDeployVersionRepository;
+import org.glue.glue_be.main.response.MainResponseStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MainService {
+
+    private final MainCarouselRepository mainCarouselRepository;
+    private final CarouselDeployVersionRepository deployVersionRepository;
+    private final FileService fileService;
+
+    // 조회 (배포 버전 기준)
+    @Transactional(readOnly = true)
+    public MainCarouselResponse getCarouselImages(String version) {
+        // admin 페이지가 아니라 프론트에서 이 서비스를 호출할 땐 version 파라미터를 주지 않을 것
+        // 그러므로 version이 파라미터로 들어오지 않을 땐 현재 배포되어 있는 버전을 조회
+        if (version == null || version.trim().isEmpty()) {
+            version = getCurrentDeployVersion();
+        }
+
+        List<MainCarousel> carousels = getCarouselsByVersion(version);
+
+        List<CarouselImageDto> images = carousels.stream()
+                .map(CarouselImageDto::fromEntity)
+                .collect(Collectors.toList());
+
+        return new MainCarouselResponse(version, images, images.size());
+    }
+
+    // 현재 배포 버전 조회
+    @Transactional(readOnly = true)
+    public String getCurrentDeployVersion() {
+        return getActiveDeployVersion()
+                .map(CarouselDeployVersion::getVersion)
+                .orElseThrow(() -> new BaseException(MainResponseStatus.NO_ACTIVE_DEPLOY_VERSION));
+    }
+
+    // 배포 버전 설정
+    @Transactional
+    public CarouselDeployVersionResponse setDeployVersion(CarouselDeployVersionRequest request) {
+        validateDeployVersionRequest(request);
+
+        // 해당 버전의 캐러셀이 존재하는지 확인
+        List<MainCarousel> carousels = getCarouselsByVersion(request.version());
+        if (carousels.isEmpty()) {
+            throw new BaseException(MainResponseStatus.NO_CAROUSELS_FOR_VERSION);
+        }
+
+        // 기존 활성 버전 비활성화
+        getActiveDeployVersion().ifPresent(CarouselDeployVersion::deactivate);
+
+        // 새 버전을 활성화하거나 생성
+        CarouselDeployVersion deployVersion = getDeployVersionByVersion(request.version())
+                .orElse(request.toEntity());
+
+        if (deployVersion.getId() != null) {
+            // 기존 버전 업데이트
+            deployVersion.updateVersion(request.version(), request.description());
+            deployVersion.activate();
+        }
+
+        CarouselDeployVersion saved = deployVersionRepository.save(deployVersion);
+
+        return CarouselDeployVersionResponse.fromEntity(saved);
+    }
+
+    // 모든 버전 목록 조회
+    @Transactional(readOnly = true)
+    public CarouselVersionResponse getAllVersions() {
+        List<String> versions = getAllCarouselVersions();
+        return new CarouselVersionResponse(versions, versions.size());
+    }
+
+    // 등록용 Presigned URL 생성
+    @Transactional
+    public CarouselPresignedUrlResponse createPresignedUrlForUpload(MainCarouselCreateRequest request) {
+        validateCreateRequest(request);
+
+        // displayOrder 자동 설정 (현재 버전의 최대값 + 1)
+        Integer maxOrder = getMaxDisplayOrderByVersion(request.version());
+        Integer displayOrder = (maxOrder != null ? maxOrder : 0) + 1;
+
+        // 파일 확장자 추출
+        String imageExtension = extractFileExtension(request.fileName());
+
+        // 기존 FileService 활용
+        GetPresignedUrlResponse s3Response = fileService.getCarouselPresignedUrl(request.fileName(), imageExtension);
+
+        // DB에 저장
+        MainCarousel carousel = request.toEntity(s3Response.getPublicUrl(), displayOrder);
+
+        MainCarousel savedCarousel = mainCarouselRepository.save(carousel);
+
+        return CarouselPresignedUrlResponse.fromEntity(s3Response, request.fileName(), savedCarousel.getId());
+    }
+
+    // 버전별 일괄 삭제
+    @Transactional
+    public CarouselBulkDeleteResponse deleteCarouselsByVersion(String version) {
+        if (version == null || version.trim().isEmpty()) {
+            throw new BaseException(MainResponseStatus.VERSION_REQUIRED);
+        }
+
+        // 해당 버전의 모든 캐러셀 조회
+        List<MainCarousel> carousels = getCarouselsByVersion(version);
+
+        if (carousels.isEmpty()) {
+            return new CarouselBulkDeleteResponse(version, 0, 0, 0);
+        }
+
+        int totalCount = carousels.size();
+        int successCount = 0;
+        int failedCount = 0;
+
+        // 각 캐러셀 삭제 처리
+        for (MainCarousel carousel : carousels) {
+            try {
+                // S3에서 이미지 삭제 시도
+                if (carousel.getImageUrl() != null) {
+                    try {
+                        fileService.deleteFile(carousel.getImageUrl());
+                    } catch (Exception e) {
+                        System.err.println("Failed to delete S3 file for carousel ID " + carousel.getId() + ": " + e.getMessage());
+                        // S3 삭제 실패해도 DB 삭제는 계속 진행
+                    }
+                }
+
+                // DB에서 삭제
+                mainCarouselRepository.delete(carousel);
+                successCount++;
+
+            } catch (Exception e) {
+                System.err.println("Failed to delete carousel ID " + carousel.getId() + ": " + e.getMessage());
+                failedCount++;
+            }
+        }
+
+        return new CarouselBulkDeleteResponse(version, totalCount, successCount, failedCount);
+    }
+
+    private List<MainCarousel> getCarouselsByVersion(String version) {
+        return mainCarouselRepository.findByVersionOrderByDisplayOrder(version);
+    }
+
+    private Optional<CarouselDeployVersion> getActiveDeployVersion() {
+        return deployVersionRepository.findByIsActiveTrue();
+    }
+
+    private Optional<CarouselDeployVersion> getDeployVersionByVersion(String version) {
+        return deployVersionRepository.findByVersion(version);
+    }
+
+    private List<String> getAllCarouselVersions() {
+        return mainCarouselRepository.findAllVersions();
+    }
+
+    private Integer getMaxDisplayOrderByVersion(String version) {
+        return mainCarouselRepository.findMaxDisplayOrderByVersion(version);
+    }
+
+    private void validateDeployVersionRequest(CarouselDeployVersionRequest request) {
+        if (request.version() == null || request.version().trim().isEmpty()) {
+            throw new BaseException(MainResponseStatus.VERSION_REQUIRED);
+        }
+    }
+
+    private String extractFileExtension(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            throw new BaseException(MainResponseStatus.INVALID_FILE_NAME);
+        }
+        return fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
+    }
+
+    private void validateCreateRequest(MainCarouselCreateRequest request) {
+        if (request.version() == null || request.version().trim().isEmpty()) {
+            throw new BaseException(MainResponseStatus.VERSION_REQUIRED);
+        }
+        if (request.fileName() == null || request.fileName().trim().isEmpty()) {
+            throw new BaseException(MainResponseStatus.FILE_NAME_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/org/glue/glue_be/setting/CorsConfig.java
+++ b/src/main/java/org/glue/glue_be/setting/CorsConfig.java
@@ -1,0 +1,19 @@
+package org.glue.glue_be.setting;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/src/main/java/org/glue/glue_be/setting/SecurityConfig.java
+++ b/src/main/java/org/glue/glue_be/setting/SecurityConfig.java
@@ -11,7 +11,9 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @RequiredArgsConstructor // for DI fields
@@ -30,7 +32,7 @@ public class SecurityConfig {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http
+		http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.csrf(AbstractHttpConfigurer::disable)
 			.formLogin(form -> form.disable()) // 폼 로그인 비활성화
 			.sessionManagement(session -> {
@@ -51,5 +53,18 @@ public class SecurityConfig {
 
 
 		return http.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.addAllowedOriginPattern("*");
+		configuration.addAllowedMethod("*");
+		configuration.addAllowedHeader("*");
+		configuration.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/src/main/resources/static/s3-test-2.html
+++ b/src/main/resources/static/s3-test-2.html
@@ -1,0 +1,601 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>MainCarousel API Test</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .section {
+            background: white;
+            margin: 20px 0;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .form-group {
+            margin: 10px 0;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        input, select, textarea, button {
+            padding: 8px;
+            margin: 5px 0;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+        }
+        input[type="text"], input[type="number"], select, textarea {
+            width: 300px;
+        }
+        button {
+            background: #007bff;
+            color: white;
+            border: none;
+            cursor: pointer;
+            padding: 10px 20px;
+        }
+        button:hover {
+            background: #0056b3;
+        }
+        button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .delete-btn {
+            background: #dc3545;
+        }
+        .delete-btn:hover {
+            background: #c82333;
+        }
+        .deploy-btn {
+            background: #28a745;
+        }
+        .deploy-btn:hover {
+            background: #218838;
+        }
+        textarea {
+            width: 100%;
+            height: 120px;
+            font-family: monospace;
+        }
+        .carousel-item {
+            border: 1px solid #ddd;
+            margin: 10px 0;
+            padding: 15px;
+            border-radius: 4px;
+            background: #f9f9f9;
+        }
+        .carousel-image {
+            max-width: 200px;
+            max-height: 150px;
+            border-radius: 4px;
+            margin: 10px 0;
+        }
+        .status {
+            padding: 10px;
+            margin: 10px 0;
+            border-radius: 4px;
+        }
+        .status.success {
+            background: #d4edda;
+            color: #155724;
+            border: 1px solid #c3e6cb;
+        }
+        .status.error {
+            background: #f8d7da;
+            color: #721c24;
+            border: 1px solid #f5c6cb;
+        }
+        .status.info {
+            background: #d1ecf1;
+            color: #0c5460;
+            border: 1px solid #bee5eb;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+        .deploy-status {
+            background: #e7f3ff;
+            border: 2px solid #007bff;
+            padding: 15px;
+            border-radius: 8px;
+            margin: 15px 0;
+        }
+        .deploy-status.active {
+            background: #d4edda;
+            border-color: #28a745;
+        }
+        @media (max-width: 768px) {
+            .grid, .grid-three {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+<h1>🎠 MainCarousel API Test (with Deploy Version Management)</h1>
+
+<!-- 0. 배포 버전 관리 섹션 -->
+<div class="section">
+    <h2>🚀 배포 버전 관리 (관리자)</h2>
+    <div id="currentDeployStatus" class="deploy-status"></div>
+
+    <div class="grid">
+        <div>
+            <h3>현재 배포 버전 확인</h3>
+            <button onclick="loadCurrentDeployVersion()" class="deploy-btn">🔍 현재 배포 버전 조회</button>
+            <div id="deployStatusDisplay"></div>
+        </div>
+
+        <div>
+            <h3>새 배포 버전 설정</h3>
+            <div class="form-group">
+                <label>배포할 버전:</label>
+                <select id="deployVersionSelect" style="width: 200px;">
+                    <option value="">버전을 선택하세요</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label>배포 설명:</label>
+                <input type="text" id="deployDescription" placeholder="배포 설명 (선택사항)">
+            </div>
+            <button onclick="setDeployVersion()" class="deploy-btn" id="deployBtn">🚀 배포 버전 설정</button>
+            <div id="deploySetStatus"></div>
+        </div>
+    </div>
+</div>
+
+<!-- 1. 조회 섹션 -->
+<div class="section">
+    <h2>📋 1. 캐러셀 조회</h2>
+    <div class="form-group">
+        <label>Version (선택사항):</label>
+        <select id="queryVersion" style="width: 200px;">
+            <option value="">현재 배포 버전 자동 조회</option>
+        </select>
+        <button onclick="loadVersions()">🔄 버전 목록 새로고침</button>
+        <button onclick="loadCarousels()">조회</button>
+    </div>
+    <div id="versionStatus"></div>
+    <div id="bulkDeleteStatus"></div>
+    <div id="carouselList"></div>
+</div>
+
+<!-- 2. 등록 섹션 -->
+<div class="section">
+    <h2>➕ 2. 캐러셀 등록</h2>
+    <div class="form-group">
+        <label>Version:</label>
+        <select id="createVersion" style="width: 200px;">
+            <option value="">기존 버전 선택</option>
+        </select>
+        <input type="text" id="createVersionInput" placeholder="새 버전 직접 입력 (예: v2.0)" style="width: 200px; margin-left: 10px;">
+    </div>
+    <div class="form-group">
+        <label>Description:</label>
+        <input type="text" id="createDescription" placeholder="이미지 설명">
+    </div>
+    <div class="form-group">
+        <label>이미지 파일:</label>
+        <input type="file" id="createImageInput" accept="image/*">
+    </div>
+    <p style="font-size: 12px; color: #666; margin: 5px 0;">
+        💡 순서는 자동으로 설정됩니다 (현재 버전의 마지막 + 1)
+    </p>
+    <button onclick="createCarousel()" id="createBtn">등록</button>
+    <div id="createStatus"></div>
+</div>
+
+<!-- 5. 로그 섹션 -->
+<div class="section">
+    <h2>📝 API 응답 로그</h2>
+    <textarea id="logArea" readonly placeholder="API 응답이 여기에 표시됩니다..."></textarea>
+    <button onclick="clearLog()">로그 클리어</button>
+</div>
+
+<script>
+    const API_BASE = 'http://localhost:8080/api/main/carousel';
+    const logArea = document.getElementById('logArea');
+
+    // 로그 추가 함수
+    function addLog(message, type = 'info') {
+        const timestamp = new Date().toLocaleTimeString();
+        logArea.value += `[${timestamp}] ${message}\n`;
+        logArea.scrollTop = logArea.scrollHeight;
+        console.log(message);
+    }
+
+    // 로그 클리어
+    function clearLog() {
+        logArea.value = '';
+    }
+
+    // 상태 표시 함수
+    function showStatus(elementId, message, type = 'info') {
+        const element = document.getElementById(elementId);
+        element.innerHTML = `<div class="status ${type}">${message}</div>`;
+        setTimeout(() => {
+            element.innerHTML = '';
+        }, 10000);
+    }
+
+    // 0. 현재 배포 버전 조회
+    async function loadCurrentDeployVersion() {
+        try {
+            addLog('현재 배포 버전 조회 시작');
+            const response = await fetch(`${API_BASE}/deploy-version`);
+
+            if (response.ok) {
+                const version = await response.text(); // String 응답이므로 text()로 받음
+                await displayCurrentDeployVersionSimple(version);
+                addLog(`현재 배포 버전: ${version}`, 'success');
+            } else {
+                throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+            }
+        } catch (error) {
+            addLog(`배포 버전 조회 실패: ${error.message}`, 'error');
+            showStatus('deployStatusDisplay', `❌ ${error.message}`, 'error');
+
+            // 배포 버전이 없는 경우 안내 메시지
+            const container = document.getElementById('currentDeployStatus');
+            container.className = 'deploy-status';
+            container.innerHTML = `
+                    <h3>⚠️ 배포 버전이 설정되지 않았습니다</h3>
+                    <p>아래에서 배포할 버전을 선택하여 설정해주세요.</p>
+                `;
+        }
+    }
+
+    // 간단한 배포 버전 표시 (버전 문자열만 받는 경우)
+    async function displayCurrentDeployVersionSimple(version) {
+        try {
+            // 해당 버전의 캐러셀 정보를 조회해서 추가 정보 표시
+            const carouselResponse = await fetch(`${API_BASE}?version=${version}`);
+            if (carouselResponse.ok) {
+                const data = await carouselResponse.json();
+                displayCurrentDeployVersion({
+                    version: version,
+                    description: `현재 배포 버전 (자동 조회)`,
+                    hasCarousels: data.totalCount > 0,
+                    carouselCount: data.totalCount
+                });
+            } else {
+                // 캐러셀 조회 실패 시 기본 정보만 표시
+                displayCurrentDeployVersion({
+                    version: version,
+                    description: `현재 배포 버전`,
+                    hasCarousels: false,
+                    carouselCount: 0
+                });
+            }
+        } catch (error) {
+            // 에러 발생 시 기본 정보만 표시
+            displayCurrentDeployVersion({
+                version: version,
+                description: `현재 배포 버전`,
+                hasCarousels: false,
+                carouselCount: 0
+            });
+        }
+    }
+
+    // 현재 배포 버전 표시
+    function displayCurrentDeployVersion(data) {
+        const container = document.getElementById('currentDeployStatus');
+        const statusClass = data.hasCarousels ? 'active' : '';
+
+        container.className = `deploy-status ${statusClass}`;
+        container.innerHTML = `
+                <h3>🚀 현재 배포 중: ${data.version}</h3>
+                <p><strong>설명:</strong> ${data.description || '없음'}</p>
+                <p><strong>캐러셀:</strong> ${data.carouselCount}개 ${data.hasCarousels ? '✅' : '❌'}</p>
+                <p><strong>상태:</strong> ${data.hasCarousels ? '정상 배포 중' : '캐러셀 없음 (배포 불가)'}</p>
+            `;
+
+        const statusMessage = data.hasCarousels
+            ? `현재 "${data.version}" 버전이 배포 중입니다. (${data.carouselCount}개 캐러셀)`
+            : `현재 "${data.version}" 버전이 배포 중이지만 캐러셀이 없습니다.`;
+
+        showStatus('deployStatusDisplay', statusMessage, data.hasCarousels ? 'success' : 'error');
+    }
+
+    // 배포 버전 설정
+    async function setDeployVersion() {
+        const version = document.getElementById('deployVersionSelect').value;
+        const description = document.getElementById('deployDescription').value;
+
+        if (!version) {
+            alert('배포할 버전을 선택하세요.');
+            return;
+        }
+
+        const deployBtn = document.getElementById('deployBtn');
+        deployBtn.disabled = true;
+
+        try {
+            addLog(`배포 버전 설정 시작: ${version}`);
+            showStatus('deploySetStatus', '배포 버전 설정 중...', 'info');
+
+            const requestBody = {
+                version: version,
+                description: description || null
+            };
+
+            const response = await fetch(`${API_BASE}/deploy-version`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(requestBody)
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                throw new Error(`배포 설정 실패: HTTP ${response.status} - ${errorText}`);
+            }
+
+            const result = await response.json();
+            addLog(`배포 버전 설정 완료: ${result.version} (활성: ${result.isActive})`, 'success');
+            showStatus('deploySetStatus', `✅ "${result.version}" 버전이 배포되었습니다!`, 'success');
+
+            // 폼 초기화
+            document.getElementById('deployVersionSelect').value = '';
+            document.getElementById('deployDescription').value = '';
+
+            // 현재 배포 버전 새로고침
+            setTimeout(() => loadCurrentDeployVersion(), 1000);
+
+        } catch (error) {
+            addLog(`배포 버전 설정 실패: ${error.message}`, 'error');
+            showStatus('deploySetStatus', `❌ 배포 실패: ${error.message}`, 'error');
+        } finally {
+            deployBtn.disabled = false;
+        }
+    }
+
+    // 1. 버전 목록 로드
+    async function loadVersions() {
+        try {
+            addLog('버전 목록 조회 시작');
+            const response = await fetch(`${API_BASE}/versions`);
+            const data = await response.json();
+
+            if (response.ok) {
+                updateVersionDropdowns(data.versions);
+                addLog(`버전 목록 조회 성공: ${data.totalCount}개 버전`, 'success');
+                showStatus('versionStatus', `📋 총 ${data.totalCount}개 버전 발견`, 'info');
+            } else {
+                throw new Error(`HTTP ${response.status}: ${JSON.stringify(data)}`);
+            }
+        } catch (error) {
+            addLog(`버전 목록 조회 실패: ${error.message}`, 'error');
+            showStatus('versionStatus', `❌ 버전 목록 조회 실패: ${error.message}`, 'error');
+        }
+    }
+
+    // 버전 드롭다운 업데이트
+    function updateVersionDropdowns(versions) {
+        const querySelect = document.getElementById('queryVersion');
+        const createSelect = document.getElementById('createVersion');
+        const deploySelect = document.getElementById('deployVersionSelect');
+
+        // 조회용 드롭다운
+        querySelect.innerHTML = '<option value="">현재 배포 버전 자동 조회</option>';
+        versions.forEach(version => {
+            querySelect.innerHTML += `<option value="${version}">${version}</option>`;
+        });
+
+        // 등록용 드롭다운
+        createSelect.innerHTML = '<option value="">기존 버전 선택</option>';
+        versions.forEach(version => {
+            createSelect.innerHTML += `<option value="${version}">${version}</option>`;
+        });
+
+        // 배포용 드롭다운
+        deploySelect.innerHTML = '<option value="">배포할 버전 선택</option>';
+        versions.forEach(version => {
+            deploySelect.innerHTML += `<option value="${version}">${version}</option>`;
+        });
+    }
+
+    // 2. 캐러셀 조회
+    async function loadCarousels() {
+        const version = document.getElementById('queryVersion').value;
+        // version이 비어있으면 배포 버전 자동 조회
+
+        try {
+            const versionText = version || '현재 배포 버전';
+            addLog(`캐러셀 조회 시작: ${versionText}`);
+
+            const url = version ? `${API_BASE}?version=${version}` : API_BASE;
+            const response = await fetch(url);
+            const data = await response.json();
+
+            if (response.ok) {
+                displayCarousels(data);
+                addLog(`캐러셀 조회 성공: ${data.version} 버전 ${data.totalCount}개`, 'success');
+            } else {
+                throw new Error(`HTTP ${response.status}: ${JSON.stringify(data)}`);
+            }
+        } catch (error) {
+            addLog(`캐러셀 조회 실패: ${error.message}`, 'error');
+        }
+    }
+
+    // 캐러셀 목록 표시
+    function displayCarousels(data) {
+        const container = document.getElementById('carouselList');
+        if (data.totalCount === 0) {
+            container.innerHTML = `<p>버전 "${data.version}"에 등록된 캐러셀이 없습니다.</p>`;
+            return;
+        }
+
+        let html = `
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
+                    <h3>총 ${data.totalCount}개의 캐러셀 (Version: ${data.version})</h3>
+                    <button onclick="bulkDeleteCarousels('${data.version}')" class="delete-btn" style="font-size: 12px; padding: 5px 10px;">
+                        🗑️ 전체 삭제 (${data.totalCount}개)
+                    </button>
+                </div>
+            `;
+
+        data.images.forEach(item => {
+            html += `
+                    <div class="carousel-item">
+                        <strong>ID:</strong> ${item.id} |
+                        <strong>Order:</strong> ${item.displayOrder} |
+                        <strong>Description:</strong> ${item.description || '없음'}
+                        <br>
+                        <img src="${item.imageUrl}" alt="Carousel ${item.id}" class="carousel-image"
+                             onerror="this.src='data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZGRkIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIGZvbnQtZmFtaWx5PSJBcmlhbCIgZm9udC1zaXplPSIxNCIgZmlsbD0iIzk5OSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZHk9Ii4zZW0iPuydtOuvuOyngCDroZzrk5wg7Iuk7YyoPC90ZXh0Pjwvc3ZnPg=='">
+                        <br>
+                        <small>URL: ${item.imageUrl}</small>
+                        <br>
+                        <button class="delete-btn" onclick="deleteCarousel(${item.id})" style="font-size: 12px; padding: 3px 8px;">삭제</button>
+                    </div>
+                `;
+        });
+        container.innerHTML = html;
+    }
+
+    // 3. 캐러셀 등록
+    async function createCarousel() {
+        const selectedVersion = document.getElementById('createVersion').value;
+        const inputVersion = document.getElementById('createVersionInput').value;
+        const version = inputVersion || selectedVersion;
+        const description = document.getElementById('createDescription').value;
+        const fileInput = document.getElementById('createImageInput');
+        const file = fileInput.files[0];
+
+        if (!version || !file) {
+            alert('Version과 이미지 파일을 입력하세요.');
+            return;
+        }
+
+        const createBtn = document.getElementById('createBtn');
+        createBtn.disabled = true;
+
+        try {
+            addLog(`캐러셀 등록 시작: ${file.name} (버전: ${version})`);
+            showStatus('createStatus', '업로드 URL 생성 중...', 'info');
+
+            const requestBody = {
+                version: version,
+                fileName: file.name,
+                description: description
+            };
+
+            const presignResponse = await fetch(`${API_BASE}/presigned-url`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(requestBody)
+            });
+
+            if (!presignResponse.ok) {
+                const errorData = await presignResponse.json();
+                throw new Error(`Presigned URL 생성 실패: ${JSON.stringify(errorData)}`);
+            }
+
+            const { presignedUrl, publicUrl, carouselId } = await presignResponse.json();
+            addLog(`Presigned URL 생성 성공: ID=${carouselId}`);
+
+            showStatus('createStatus', 'S3에 이미지 업로드 중...', 'info');
+            const uploadResponse = await fetch(presignedUrl, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': file.type
+                },
+                body: file
+            });
+
+            if (!uploadResponse.ok) {
+                throw new Error(`S3 업로드 실패: ${uploadResponse.status}`);
+            }
+
+            addLog(`캐러셀 등록 완료: ID=${carouselId}`, 'success');
+            showStatus('createStatus', `✅ 등록 완료! (ID: ${carouselId})`, 'success');
+
+            // 폼 초기화
+            document.getElementById('createDescription').value = '';
+            document.getElementById('createVersionInput').value = '';
+            fileInput.value = '';
+
+            // 목록 새로고침
+            setTimeout(() => {
+                loadVersions();
+                loadCarousels();
+            }, 1000);
+
+        } catch (error) {
+            addLog(`캐러셀 등록 실패: ${error.message}`, 'error');
+            showStatus('createStatus', `❌ 등록 실패: ${error.message}`, 'error');
+        } finally {
+            createBtn.disabled = false;
+        }
+    }
+
+    // 6. 버전별 일괄 삭제
+    async function bulkDeleteCarousels(targetVersion) {
+        const version = targetVersion || document.getElementById('queryVersion').value;
+        if (!version) {
+            alert('삭제할 버전을 선택하세요.');
+            return;
+        }
+
+        const carouselList = document.getElementById('carouselList');
+        const currentItems = carouselList.querySelectorAll('.carousel-item').length;
+
+        let confirmMessage = `정말로 "${version}" 버전의 모든 캐러셀을 삭제하시겠습니까?`;
+        if (currentItems > 0) {
+            confirmMessage += `\n\n현재 ${currentItems}개의 항목이 삭제됩니다.`;
+        }
+        confirmMessage += '\n\n⚠️ 이 작업은 되돌릴 수 없습니다!';
+
+        if (!confirm(confirmMessage)) {
+            return;
+        }
+
+        try {
+            addLog(`버전별 일괄 삭제 시작: version=${version}`);
+            showStatus('bulkDeleteStatus', '일괄 삭제 진행 중...', 'info');
+
+            const response = await fetch(`${API_BASE}/version/${version}`, {
+                method: 'DELETE'
+            });
+
+            if (!response.ok) {
+                const errorData = await response.text();
+                throw new Error(`일괄 삭제 실패: HTTP ${response.status} ${errorData}`);
+            }
+
+            const result = await response.json();
+
+            if (result.totalCount === 0) {
+                addLog(`일괄 삭제 완료: 삭제할 항목이 없었습니다.`, 'info');
+                showStatus('bulkDeleteStatus', '삭제할 항목이 없습니다.', 'info');
+            } else if (result.allSuccess) {
+                addLog(`일괄 삭제 완료: ${result.summary}`, 'success');
+                showStatus('bulkDeleteStatus', `✅ ${result.summary}`, 'success');
+            } else {
+                addLog(`일괄 삭제 부분 완료: ${result.summary}`, 'error');
+                showStatus('bulkDeleteStatus', `⚠️ ${result.summary}`, 'error');
+            }
+        } catch (error) {
+                addLog(`캐러셀 삭제 실패: ${error.message}`, 'error');
+                showStatus('deleteStatus', `❌ 삭제 실패: ${error.message}`, 'error');
+            }
+    }
+</script>


### PR DESCRIPTION
# 구현 사항
## API
### 1. 현재 배포되어 있는 버전에 대한 사진들 조회
- 프론트에서 사용하는 api는 이거 하나입니다. 
- 하단의 api들은 모두 admin 용입니다.

### 2. 모든 버전 조회

<img width="455" alt="image" src="https://github.com/user-attachments/assets/3b5fdc42-3f46-4993-871d-fa3e9cbf452b" />

- admin 페이지에서 버전별 캐러셀 정보들을 조회해야 하는데, 어떤 버전들이 현재 저장되어 있는지 불러오는 api입니다.

### 3. 현재 배포되어 있는 버전 조회
- 현재 프론트에 어떤 버전이 배포되어 있는지를 어드민 페이지에서 확인할 수 있어야 한다고 생각했습니다.

### 4. 배포 버전 설정
- 예를 들어 데이터베이스에 버전 1.0, 1.1이 있다면, 둘 중 하나의 버전을 배포할 수 있도록 합니다.
- 캐러셀 사진들을 어떤 식으로 관리해야 할지 생각을 해봤는데, 버저닝을 하는 게 관리 측면에서 가장 효과적이라고 생각했습니다.
- 이유는 다음과 같습니다.
   - 예를 들어, 1.0은 보통의 상황에서 띄우는 공지 캐러셀 하나, 1.1에는 보통의 상황에서 띄우는 공지 캐러셀과 하이드아웃 파티 캐러셀로 총 두 개의 캐러셀이 있다고 가정해봅시다.
   - 1.1의 하이드아웃 파티 관련 내용은 이틀만 띄우고 싶고, 다른 날에는 띄우고 싶지 않다고 했을 때,
   - 1.1을 이틀 띄우고 난 뒤 "1.0으로 롤백"할 수 있는 기능이 필요하다고 생각했습니다.
- 이러한 시나리오에서 버저닝이 아닌 일반적인 사진 순서 수정을 한다면 더 번거로워질 것이라고 판단하여 버저닝 방식을 채택했습니다.
- 단, 앱의 버전과 캐러셀의 버전은 완전히 별개입니다.
- 따라서 사실 캐러셀 버전은 1.0, 1.1와 같은 실수보다 1, 2, 3, 4 등의 정수가 더 효과적일 수도 있습니다.
- 다만, 유연성을 고려하여 어떤 것도 다 해당할 수 있도록 버전의 자료형은 String으로 두었습니다.

### 5. presigned url 등록
- 시웅님께서 기존에 만드신 로직을 거의 그대로 사용했습니다.
- 사진의 순서는 관리자가 조정할 수 없고, 등록한 순서대로 등록되도록 했습니다.
- 이 역시 순서의 개념이 도입되면 버저닝의 의미가 흐려질 것이라 판단했습니다.
- 순서를 잘못 등록했다면, 해당 버전에 있는 사진들을 일괄 삭제 후 사진을 모두 다시 추가해야 합니다.

### 6. 버전별 일괄 삭제
- 각 버전의 사진을 하나하나 관리하는 것은 위에서 언급한 버저닝의 의미가 흐려지고, 오히려 관리가 어려울 것이라 판단했습니다.
- 따라서 버전별로 일괄 삭제하는 기능을 추가했습니다.

## Entity
### 1. main_carousel
- 기존에 논의하며 새로 만들기로 했던 테이블입니다.
- 단, 어드민 페이지에서 좀 더 쉽게 사진들을 식별할 수 있도록 설명 속성을 추가하고, 버저닝을 위해 버전 속성을 추가했습니다.

### 2. carousel_deploy_version
- 많은 버전 중, 어떤 버전이 현재 배포되어 있는 버전인지 관리하는 테이블입니다.
- 테이블을 추가하지 않는 방법도 생각해봤는데, 추가하는 것이 active 상태를 추적하기에 더 용이할 것이라 판단했습니다.

# 시연 영상

아래와 같이 배포하고 싶은 버전과 그에 넣고 싶은 사진을 추가할 수 있을 겁니다.

https://github.com/user-attachments/assets/7d274a6b-6632-48de-aff8-70fb5816a900


또한, 아래와 같이 버전 삭제를 할 수 있을 겁니다.


https://github.com/user-attachments/assets/d3781efc-ad0b-49c4-bcbd-892c2c737d01




close #78 