### PR TITLE
feat: Swagger 설정 및 API 문서화 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'org.xerial:sqlite-jdbc:3.41.2.2' // sqlite jdbc
     implementation 'org.hibernate.orm:hibernate-community-dialects' // sqlite3 dialect
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'

--- a/src/main/java/org/glue/glue_be/auth/controller/AppleLoginController.java
+++ b/src/main/java/org/glue/glue_be/auth/controller/AppleLoginController.java
@@ -1,5 +1,9 @@
 package org.glue.glue_be.auth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,18 +19,21 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth/apple")
+@Tag(name = "Apple Auth", description = "애플 API")
 public class AppleLoginController {
 
     private final AuthService authService;
 
 
     @PostMapping("/signup")
+    @Operation(summary = "애플 회원가입")
     public BaseResponse<AppleSignUpResponseDto> appleSignUp(@Valid @RequestBody AppleSignUpRequestDto requestDto) {
         AppleSignUpResponseDto responseDto = authService.appleSignUp(requestDto);
         return new BaseResponse<>(responseDto);
     }
 
     @PostMapping("/signin")
+    @Operation(summary = "애플 로그인")
     public BaseResponse<AppleSignInResponseDto> appleSignIn(@Valid @RequestBody AppleSignInRequestDto requestDto) {
         AppleSignInResponseDto responseDto = authService.appleSignIn(requestDto);
         return new BaseResponse<>(responseDto);

--- a/src/main/java/org/glue/glue_be/auth/controller/AuthController.java
+++ b/src/main/java/org/glue/glue_be/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package org.glue.glue_be.auth.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -14,17 +16,20 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @Validated
 @RequestMapping("/api/auth")
+@Tag(name = "Auth", description = "인증 및 권한 API")
 public class AuthController {
 
 	private final AuthService authService;
 
 	@PostMapping("/code")
+	@Operation(summary = "이메일 인증 코드 전송")
 	BaseResponse<Void> sendCode(@RequestParam("email") @Email(message = "유효한 이메일 형식이 아닙니다") String email) {
 		authService.sendCode(email);
 		return new BaseResponse<>();
 	}
 
 	@GetMapping("/verify-code")
+	@Operation(summary = "이메일 인증 코드 확인")
 	BaseResponse<Boolean> verifyCode(
 		@RequestParam("email") @Email(message = "유효한 이메일 형식이 아닙니다") String email,
 		@RequestParam("code") String code) {

--- a/src/main/java/org/glue/glue_be/auth/controller/KakaoLoginController.java
+++ b/src/main/java/org/glue/glue_be/auth/controller/KakaoLoginController.java
@@ -1,6 +1,8 @@
 package org.glue.glue_be.auth.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,12 +19,14 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth/kakao")
+@Tag(name = "Kakao Auth", description = "카카오 API")
 public class KakaoLoginController {
 
 	private final AuthService authService;
 
 	// 회원가입
 	@PostMapping("/signup")
+	@Operation(summary = "카카오 회원가입")
 	public BaseResponse<KakaoSignUpResponseDto> kakaoSignUp(@RequestBody @Valid KakaoSignUpRequestDto requestDto){
 		KakaoSignUpResponseDto responseDto = authService.kakaoSignUp(requestDto);
 		return new BaseResponse<>(responseDto);
@@ -31,6 +35,7 @@ public class KakaoLoginController {
 
 	// 로그인
 	@PostMapping("/signin")
+	@Operation(summary = "카카오 로그인")
 	public BaseResponse<KakaoSignInResponseDto> kakaoSignIn(@RequestBody @Valid KakaoSignInRequestDto requestDto){
 		KakaoSignInResponseDto responseDto = authService.kakaoSignIn(requestDto);
 

--- a/src/main/java/org/glue/glue_be/aws/controller/S3BucketController.java
+++ b/src/main/java/org/glue/glue_be/aws/controller/S3BucketController.java
@@ -1,5 +1,8 @@
 package org.glue.glue_be.aws.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
 import org.glue.glue_be.aws.dto.GetPresignedUrlResponse;
@@ -11,19 +14,25 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/aws/presigned-url")
+@Tag(name = "AWS S3", description = "AWS S3 Presigned URL 관련 API")
 public class S3BucketController {
 
-	private final FileService fileService;
+    private final FileService fileService;
 
 
-	// bucketObject: S3 버킷의 폴더명 지정 -> post_images or profile_images
-	// extension: 파일의 확장자
-	@PostMapping
-	public GetPresignedUrlResponse getPresignedUrl(
-		@RequestParam String bucketObject,
-		@RequestParam String extension,
-		@AuthenticationPrincipal CustomUserDetails auth) {
+    // bucketObject: S3 버킷의 폴더명 지정 -> post_images or profile_images
+    // extension: 파일의 확장자
+    @PostMapping
+    @Operation(summary = "S3 Presigned URL 발급")
+    public GetPresignedUrlResponse getPresignedUrl(
+            @Parameter(description = "S3 버킷의 폴더명 (예: post_images, profile_images)")
+            @RequestParam String bucketObject,
 
-		return fileService.getPreSignedUrl(bucketObject, extension, auth.getUserNickname());
-	}
+            @Parameter(description = "파일 확장자 (예: jpg, png)")
+            @RequestParam String extension,
+
+            @AuthenticationPrincipal CustomUserDetails auth
+    ) {
+        return fileService.getPreSignedUrl(bucketObject, extension, auth.getUserNickname());
+    }
 }

--- a/src/main/java/org/glue/glue_be/chat/controller/DmChatController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/DmChatController.java
@@ -1,5 +1,7 @@
 package org.glue.glue_be.chat.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
 import org.glue.glue_be.chat.dto.request.DmChatRoomCreateRequest;
@@ -16,12 +18,14 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/api/dm")
 @RequiredArgsConstructor
+@Tag(name = "Dm Chat", description = "쪽지 API")
 public class DmChatController {
 
     private final DmChatService dmChatService;
 
     // Dm 채팅방 생성
     @PostMapping("/rooms/create")
+    @Operation(summary = "채팅방 생성")
     public ResponseEntity<DmChatRoomCreateResult> createDmChatRoom(@RequestBody DmChatRoomCreateRequest request, @AuthenticationPrincipal CustomUserDetails auth) {
         DmChatRoomCreateResult result = dmChatService.createDmChatRoom(request, auth.getUserId());
         return ResponseEntity.status(result.getStatus().code()).body(result);
@@ -29,6 +33,7 @@ public class DmChatController {
 
     // 채팅방 상세 정보 (채팅방 오른쪽 토글: 알림 정보, 초대 여부, 참여자 정보 확인 가능)
     @GetMapping("/rooms/{dmChatRoomId}")
+    @Operation(summary = "채팅방 상세 정보")
     public ResponseEntity<DmChatRoomDetailResponse> getDmChatRoomDetail(@PathVariable Long dmChatRoomId, @AuthenticationPrincipal CustomUserDetails auth) {
         DmChatRoomDetailResponse response = dmChatService.getDmChatRoomDetail(dmChatRoomId, Optional.ofNullable(auth.getUserId()));
         return ResponseEntity.ok(response);
@@ -36,6 +41,7 @@ public class DmChatController {
 
     // 채팅방 알림 상태 토글
     @PutMapping("/{dmChatRoomId}/toggle-push-notification")
+    @Operation(summary = "채팅방 알림 상태")
     public Integer togglePushNotification(
             @PathVariable Long dmChatRoomId, @AuthenticationPrincipal CustomUserDetails auth) {
         return dmChatService.toggleDmPushNotification(dmChatRoomId, 1L);
@@ -43,6 +49,7 @@ public class DmChatController {
 
     // 내가 호스트인 DM 채팅방 목록 조회
     @GetMapping("/rooms/hosted")
+    @Operation(summary = "내가 호스트인 DM 채팅방 목록 조회")
     public ResponseEntity<List<DmChatRoomListResponse>> getHostedDmChatRooms(
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "10") Integer pageSize,
@@ -53,6 +60,7 @@ public class DmChatController {
 
     // 내가 참석자인 DM 채팅방 목록 조회
     @GetMapping("/rooms/participated")
+    @Operation(summary = "내가 참석자인 DM 채팅방 목록 조회")
     public ResponseEntity<List<DmChatRoomListResponse>> getParticipatedDmChatRooms(
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "10") Integer pageSize,
@@ -63,6 +71,7 @@ public class DmChatController {
 
     // Dm방 나가기
     @DeleteMapping("/rooms/{dmChatRoomId}/leave")
+    @Operation(summary = "DM방 나가기")
     public ResponseEntity<List<ActionResponse>> leaveChatRoom(@PathVariable Long dmChatRoomId, @AuthenticationPrincipal CustomUserDetails auth
     ) {
         List<ActionResponse> response = dmChatService.leaveDmChatRoom(dmChatRoomId, auth.getUserId());
@@ -71,6 +80,7 @@ public class DmChatController {
 
     // Dm방 클릭 시, 대화 이력을 불러오면서 + 읽지 않은 메시지들 읽음으로 처리
     @PutMapping("/{dmChatRoomId}/all-messages")
+    @Operation(summary = "DM방 대화 이력 조회 (읽음 처리 포함)")
     public ResponseEntity<List<DmMessageResponse>> getDmMessages(
             @PathVariable Long dmChatRoomId,
             @RequestParam(required = false) Long cursorId,
@@ -82,6 +92,7 @@ public class DmChatController {
 
     // 메시지 전송
     @PostMapping("/{dmChatRoomId}/send-message")
+    @Operation(summary = "메시지 전송")
     public ResponseEntity<DmMessageResponse> sendMessage(
             @PathVariable Long dmChatRoomId,
             @RequestBody DmMessageSendRequest request,

--- a/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
@@ -21,9 +21,9 @@ public class GroupChatController {
 
     private final GroupChatService groupChatService;
 
-    // 그룹 채팅방 생성
+    // 그룹 채팅방 침야
     @GetMapping("/rooms/create/{meetingId}")
-    @Operation(summary = "그룹 채팅방 생성")
+    @Operation(summary = "그룹 채팅방 참여")
     public ResponseEntity<GroupChatRoomCreateResult> createGroupChatRoom(@PathVariable Long meetingId,
                                                                          @AuthenticationPrincipal CustomUserDetails auth) {
         GroupChatRoomCreateResult result = groupChatService.createGroupChatRoom(meetingId, auth.getUserId());

--- a/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
@@ -1,5 +1,7 @@
 package org.glue.glue_be.chat.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
 import org.glue.glue_be.chat.dto.request.GroupMessageSendRequest;
@@ -14,65 +16,81 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/group")
 @RequiredArgsConstructor
+@Tag(name = "Group Chat", description = "모임톡 API")
 public class GroupChatController {
 
     private final GroupChatService groupChatService;
 
     // 그룹 채팅방 생성
     @GetMapping("/rooms/create/{meetingId}")
-    public ResponseEntity<GroupChatRoomCreateResult> createGroupChatRoom(@PathVariable Long meetingId, @AuthenticationPrincipal CustomUserDetails auth) {
+    @Operation(summary = "그룹 채팅방 생성")
+    public ResponseEntity<GroupChatRoomCreateResult> createGroupChatRoom(@PathVariable Long meetingId,
+                                                                         @AuthenticationPrincipal CustomUserDetails auth) {
         GroupChatRoomCreateResult result = groupChatService.createGroupChatRoom(meetingId, auth.getUserId());
         return ResponseEntity.status(result.status().code()).body(result);
     }
 
     // 채팅방 상세 정보 조회
     @GetMapping("/rooms/{groupChatroomId}")
-    public ResponseEntity<GroupChatRoomDetailResponse> getGroupChatRoomDetail(@PathVariable Long groupChatroomId, @AuthenticationPrincipal CustomUserDetails auth) {
-        GroupChatRoomDetailResponse response = groupChatService.getGroupChatRoomDetail(groupChatroomId, auth.getUserId());
+    @Operation(summary = "채팅방 상세 정보 조회")
+    public ResponseEntity<GroupChatRoomDetailResponse> getGroupChatRoomDetail(@PathVariable Long groupChatroomId,
+                                                                              @AuthenticationPrincipal CustomUserDetails auth) {
+        GroupChatRoomDetailResponse response = groupChatService.getGroupChatRoomDetail(groupChatroomId,
+                auth.getUserId());
         return ResponseEntity.ok(response);
     }
 
     // 채팅방 알림 상태 토글
     @PutMapping("/{groupChatroomId}/toggle-push-notification")
-    public Integer togglePushNotification(@PathVariable Long groupChatroomId, @AuthenticationPrincipal CustomUserDetails auth) {
+    @Operation(summary = "채팅방 알림 상태")
+    public Integer togglePushNotification(@PathVariable Long groupChatroomId,
+                                          @AuthenticationPrincipal CustomUserDetails auth) {
         return groupChatService.toggleGroupPushNotification(groupChatroomId, auth.getUserId());
     }
 
     // 내가 참여 중인 그룹 채팅방 목록 조회
-        @GetMapping("/rooms/list")
+    @GetMapping("/rooms/list")
+    @Operation(summary = "참여 중인 그룹 채팅방 목록 조회")
     public ResponseEntity<List<GroupChatRoomListResponse>> getGroupChatRooms(
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "10") Integer pageSize,
             @AuthenticationPrincipal CustomUserDetails auth) {
-        List<GroupChatRoomListResponse> chatRooms = groupChatService.getGroupChatRooms(cursorId, pageSize, auth.getUserId());
+        List<GroupChatRoomListResponse> chatRooms = groupChatService.getGroupChatRooms(cursorId, pageSize,
+                auth.getUserId());
         return ResponseEntity.ok(chatRooms);
     }
 
     // 그룹 채팅방 나가기
     @DeleteMapping("/rooms/{groupChatroomId}/leave")
-    public ResponseEntity<List<ActionResponse>> leaveChatRoom(@PathVariable Long groupChatroomId, @AuthenticationPrincipal CustomUserDetails auth) {
+    @Operation(summary = "채팅방 나가기")
+    public ResponseEntity<List<ActionResponse>> leaveChatRoom(@PathVariable Long groupChatroomId,
+                                                              @AuthenticationPrincipal CustomUserDetails auth) {
         List<ActionResponse> response = groupChatService.leaveGroupChatRoom(groupChatroomId, auth.getUserId());
         return ResponseEntity.ok(response);
     }
 
     // 채팅방 클릭 시, 대화 이력을 불러오면서 + 읽지 않은 메시지들 읽음으로 처리
     @PutMapping("/{groupChatroomId}/all-messages")
+    @Operation(summary = "채팅방 대화 이력 조회 (읽음 처리 포함)")
     public ResponseEntity<List<GroupMessageResponse>> getGroupMessages(
             @PathVariable Long groupChatroomId,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "20") Integer pageSize,
             @AuthenticationPrincipal CustomUserDetails auth) {
-        List<GroupMessageResponse> messages = groupChatService.getGroupMessagesByGroupChatRoomId(groupChatroomId, cursorId, pageSize, auth.getUserId());
+        List<GroupMessageResponse> messages = groupChatService.getGroupMessagesByGroupChatRoomId(groupChatroomId,
+                cursorId, pageSize, auth.getUserId());
         return ResponseEntity.ok(messages);
     }
 
     // 메시지 전송
     @PostMapping("/{groupChatroomId}/send-message")
+    @Operation(summary = "메시지 전송")
     public ResponseEntity<GroupMessageResponse> sendMessage(
             @PathVariable Long groupChatroomId,
             @RequestBody GroupMessageSendRequest request,
             @AuthenticationPrincipal CustomUserDetails auth) {
-        GroupMessageResponse response = groupChatService.processGroupMessage(groupChatroomId, request, auth.getUserId());
+        GroupMessageResponse response = groupChatService.processGroupMessage(groupChatroomId, request,
+                auth.getUserId());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/glue/glue_be/guestbook/controller/GuestBookController.java
+++ b/src/main/java/org/glue/glue_be/guestbook/controller/GuestBookController.java
@@ -1,5 +1,7 @@
 package org.glue.glue_be.guestbook.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/guestbooks")
+@Tag(name = "Guestbook", description = "방명록 API")
 public class GuestBookController {
 
     private final GuestBookService guestBookService;
@@ -20,6 +23,7 @@ public class GuestBookController {
 
     // 작성하기
     @PostMapping
+    @Operation(summary = "방명록 작성")
     public BaseResponse<GuestBookResponse> createGuestBook(@AuthenticationPrincipal CustomUserDetails auth,
                                                            @Valid @RequestBody CreateGuestBookRequest request) {
         GuestBookResponse response = guestBookService.create(auth.getUserId(), request);
@@ -28,6 +32,7 @@ public class GuestBookController {
 
     // 방명록 조회
     @GetMapping()
+    @Operation(summary = "방명록 조회")
     public BaseResponse<GuestBookThreadResponse[]> getGuestBooks(@RequestParam Long hostId,
                                                            @RequestParam(required = false) Long cursorId,
                                                            @RequestParam(defaultValue = "10") int pageSize,
@@ -38,6 +43,7 @@ public class GuestBookController {
 
     // 방명록 개수
     @GetMapping("/count")
+    @Operation(summary = "방명록 개수 조회")
     public BaseResponse<Long> getGuestBookCount(@RequestParam Long hostId) {
         long total = guestBookService.countGuestBooks(hostId);
         return new BaseResponse<>(total);
@@ -45,6 +51,7 @@ public class GuestBookController {
 
     // 수정하기
     @PutMapping("/{guestBookId}")
+    @Operation(summary = "방명록 수정")
     public BaseResponse<GuestBookResponse> updateGuestBook(@PathVariable Long guestBookId,
                                                            @Valid @RequestBody UpdateGuestBookRequest request,
                                                            @AuthenticationPrincipal CustomUserDetails auth) {
@@ -54,6 +61,7 @@ public class GuestBookController {
 
     // 삭제하기
     @DeleteMapping("/{guestBookId}")
+    @Operation(summary = "방명록 삭제")
     public BaseResponse<Void> deleteGuestBook(@PathVariable Long guestBookId,
                                               @AuthenticationPrincipal CustomUserDetails auth) {
         guestBookService.delete(auth.getUserId(), guestBookId);

--- a/src/main/java/org/glue/glue_be/invitation/controller/InvitationController.java
+++ b/src/main/java/org/glue/glue_be/invitation/controller/InvitationController.java
@@ -1,5 +1,7 @@
 package org.glue.glue_be.invitation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.common.response.BaseResponse;
@@ -15,12 +17,14 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/invitations")
+@Tag(name = "Invitation", description = "초대장 API")
 public class InvitationController {
 
     private final InvitationService invitationService;
 
     // 모임 초대장 생성 API
     @PostMapping("/meeting/{meetingId}")
+    @Operation(summary = "모임 초대장 생성")
     public BaseResponse<InvitationDto.Response> createMeetingInvitation(
             @PathVariable Long meetingId,
             @Valid @RequestBody MeetingDto.InvitationRequest request) {
@@ -39,6 +43,7 @@ public class InvitationController {
 
     // 초대장 수락 API
     @PostMapping("/accept")
+    @Operation(summary = "모임 초대장 수락")
     public BaseResponse<Void> acceptInvitation(@Valid @RequestBody InvitationDto.AcceptRequest request) {
         Long currentUserId = getCurrentUserId();
         invitationService.acceptInvitation(request.getCode(), currentUserId);
@@ -47,6 +52,7 @@ public class InvitationController {
 
     // 초대장 목록 조회 API
     @GetMapping
+    @Operation(summary = "모임 초대장 목록 조회")
     public BaseResponse<Page<InvitationDto.Response>> getInvitations(Pageable pageable) {
         Long currentUserId = getCurrentUserId();
         return new BaseResponse<>(invitationService.getInvitations(currentUserId, pageable));

--- a/src/main/java/org/glue/glue_be/main/controller/MainController.java
+++ b/src/main/java/org/glue/glue_be/main/controller/MainController.java
@@ -1,5 +1,7 @@
 package org.glue.glue_be.main.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.main.dto.request.CarouselDeployVersionRequest;
 import org.glue.glue_be.main.dto.request.MainCarouselCreateRequest;
@@ -11,12 +13,14 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/main/carousel")
 @RequiredArgsConstructor
+@Tag(name = "Carousel", description = "캐러셀 관리 API")
 public class MainController {
 
     private final MainService mainService;
 
     // 조회
     @GetMapping
+    @Operation(summary = "메인 캐러셀 조회", description = "버전 정보에 따라 캐러셀 이미지 조회")
     public ResponseEntity<MainCarouselResponse> getCarouselImages(
             @RequestParam(required = false) String version) {
         MainCarouselResponse response = mainService.getCarouselImages(version);
@@ -26,6 +30,7 @@ public class MainController {
     // TODO: 관리자용 api들 관리자만 접근 가능하도록
     // 모든 버전 목록 조회 (관리자용)
     @GetMapping("/versions")
+    @Operation(summary = "[관리자] 캐러셀 모든 버전 목록 조회")
     public ResponseEntity<CarouselVersionResponse> getAllVersions() {
         CarouselVersionResponse response = mainService.getAllVersions();
         return ResponseEntity.ok(response);
@@ -33,12 +38,14 @@ public class MainController {
 
     // 현재 배포 버전 조회 (관리자용)
     @GetMapping("/deploy-version")
+    @Operation(summary = "[관리자] 현재 배포 중인 캐러셀 버전 조회")
     public String getCurrentDeployVersion() {
         return mainService.getCurrentDeployVersion();
     }
 
     // 배포 버전 설정 (관리자용)
     @PostMapping("/deploy-version")
+    @Operation(summary = "[관리자] 캐러셀 배포 버전 설정")
     public ResponseEntity<CarouselDeployVersionResponse> setDeployVersion(
             @RequestBody CarouselDeployVersionRequest request) {
         CarouselDeployVersionResponse response = mainService.setDeployVersion(request);
@@ -47,6 +54,7 @@ public class MainController {
 
     // 등록용 Presigned URL 생성 (관리자용)
     @PostMapping("/presigned-url")
+    @Operation(summary = "[관리자] 캐러셀 이미지 등록용 Presigned URL 생성")
     public ResponseEntity<CarouselPresignedUrlResponse> createPresignedUrlForUpload(
             @RequestBody MainCarouselCreateRequest request) {
         CarouselPresignedUrlResponse response = mainService.createPresignedUrlForUpload(request);
@@ -55,6 +63,7 @@ public class MainController {
 
     // 버전별 일괄 삭제 (관리자용)
     @DeleteMapping("/version/{version}")
+    @Operation(summary = "[관리자] 캐러셀 이미지 일괄 삭제")
     public ResponseEntity<CarouselBulkDeleteResponse> deleteCarouselsByVersion(@PathVariable String version) {
         CarouselBulkDeleteResponse response = mainService.deleteCarouselsByVersion(version);
         return ResponseEntity.ok(response);

--- a/src/main/java/org/glue/glue_be/main/controller/MainController.java
+++ b/src/main/java/org/glue/glue_be/main/controller/MainController.java
@@ -63,7 +63,7 @@ public class MainController {
 
     // 버전별 일괄 삭제 (관리자용)
     @DeleteMapping("/version/{version}")
-    @Operation(summary = "[관리자] 캐러셀 이미지 일괄 삭제")
+    @Operation(summary = "[관리자] 캐러셀 이미지 버전별 일괄 삭제")
     public ResponseEntity<CarouselBulkDeleteResponse> deleteCarouselsByVersion(@PathVariable String version) {
         CarouselBulkDeleteResponse response = mainService.deleteCarouselsByVersion(version);
         return ResponseEntity.ok(response);

--- a/src/main/java/org/glue/glue_be/meeting/controller/MeetingController.java
+++ b/src/main/java/org/glue/glue_be/meeting/controller/MeetingController.java
@@ -1,5 +1,7 @@
 package org.glue.glue_be.meeting.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
@@ -13,34 +15,29 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/meetings")
+@Tag(name = "Meeting", description = "모임 관련 API")
 public class MeetingController {
 
     private final MeetingService meetingService;
 
-    /**
-     * 모임 생성 API
-     */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "모임 생성")
     public BaseResponse<MeetingDto.CreateResponse> createMeeting(@Valid @RequestBody MeetingDto.CreateRequest request,
         @AuthenticationPrincipal CustomUserDetails auth) {
         return new BaseResponse<>(meetingService.createMeeting(request, auth.getUserId()));
     }
 
-    /**
-     * 모임 참여 API
-     */
     @GetMapping("/{meetingId}/join")
+    @Operation(summary = "모임 참여")
     public BaseResponse<Void> joinMeeting(@PathVariable Long meetingId,
         @AuthenticationPrincipal CustomUserDetails auth) {
         meetingService.joinMeeting(meetingId, auth.getUserId());
         return new BaseResponse<>();
     }
 
-    /**
-     * 모임 상세 조회 API
-     */
     @GetMapping("/{meetingId}")
+    @Operation(summary = "모임 상세 조회")
     public BaseResponse<MeetingDto.Response> getMeeting(@PathVariable Long meetingId) {
         return new BaseResponse<>(meetingService.getMeeting(meetingId));
     }

--- a/src/main/java/org/glue/glue_be/notice/controller/NoticeController.java
+++ b/src/main/java/org/glue/glue_be/notice/controller/NoticeController.java
@@ -1,6 +1,8 @@
 package org.glue.glue_be.notice.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.common.response.BaseResponse;
@@ -12,23 +14,26 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notice")
+@Tag(name = "Notice", description = "공지 API")
 public class NoticeController {
 
     private final NoticeService noticeService;
-
     @PostMapping
+    @Operation(summary = "[관리자] 공지 등록")
     public BaseResponse<NoticeResponse> create(@Valid @RequestBody NoticeRequest request) {
         NoticeResponse response = noticeService.create(request);
         return new BaseResponse<>(response);
     }
 
     @PutMapping("/{noticeId}")
+    @Operation(summary = "[관리자] 공지 수정")
     public BaseResponse<NoticeResponse> update(@PathVariable Long noticeId, @Valid @RequestBody NoticeRequest request){
         NoticeResponse response = noticeService.update(noticeId, request);
         return new BaseResponse<>(response);
     }
 
     @GetMapping
+    @Operation(summary = "공지 전체 조회")
     public BaseResponse<NoticeResponse[]> getNotices(
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "10") Integer pageSize
@@ -38,6 +43,7 @@ public class NoticeController {
     }
 
     @GetMapping("/{noticeId}")
+    @Operation(summary = "공지 상세 조회")
     public BaseResponse<NoticeResponse> getNotice(@PathVariable Long noticeId){
         NoticeResponse notice = noticeService.getNotice(noticeId);
         return new BaseResponse<>(notice);
@@ -45,6 +51,7 @@ public class NoticeController {
 
 
     @DeleteMapping("/{noticeId}")
+    @Operation(summary = "[관리자] 공지 삭제")
     public BaseResponse<Void> delete(@PathVariable Long noticeId){
         noticeService.delete(noticeId);
         return new BaseResponse<>();

--- a/src/main/java/org/glue/glue_be/notification/controller/NotificationController.java
+++ b/src/main/java/org/glue/glue_be/notification/controller/NotificationController.java
@@ -1,6 +1,8 @@
 package org.glue.glue_be.notification.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
@@ -14,18 +16,21 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notification")
+@Tag(name = "Notification", description = "알림 관련 API")
 public class NotificationController {
 
     private final NotificationService notificationService;
 
     // TODO: 테스트 용도, 개발 완료 후 삭제 예정
     @PostMapping
+    @Operation(summary = "알림 생성 (테스트용)")
     public BaseResponse<Void> create(@Valid @RequestBody CreateNotificationRequest request) {
         notificationService.create(request);
         return new BaseResponse<>();
     }
 
     @GetMapping
+    @Operation(summary = "알림 목록 조회", description = "사용자의 일반/공지 알림 목록을 조회")
     public BaseResponse<NotificationResponse[]> getNotifications(
             @AuthenticationPrincipal CustomUserDetails auth,
             @RequestParam(required = false) Long cursorId,
@@ -40,6 +45,7 @@ public class NotificationController {
 
 
     @DeleteMapping("/{notificationId}")
+    @Operation(summary = "알림 삭제")
     public BaseResponse<Void> delete(@PathVariable Long notificationId,
                                      @AuthenticationPrincipal CustomUserDetails auth) {
         notificationService.delete(notificationId, auth.getUserId());

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -1,6 +1,8 @@
 package org.glue.glue_be.post.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
+@Tag(name = "Post", description = "게시글 관련 API")
 public class PostController {
 
 	private final PostService postService;
@@ -24,6 +27,7 @@ public class PostController {
 
 	// 1. 게시글 작성 (로그인 필수)
 	@PostMapping
+	@Operation(summary = "게시글 작성")
 	public BaseResponse<CreatePostResponse> createPost(@RequestBody @Valid CreatePostRequest req, @AuthenticationPrincipal CustomUserDetails auth) {
 		return new BaseResponse<>(postService.createPost(req, auth.getUserId()));
 	}
@@ -31,6 +35,7 @@ public class PostController {
 
 	// 2. 게시글 단건 조회
 	@GetMapping("/{postId}")
+	@Operation(summary = "게시글 상세 조회")
 	public BaseResponse<GetPostResponse> getPost(@PathVariable Long postId) {
 		return new BaseResponse<>(postService.getPost(postId));
 	}
@@ -42,6 +47,7 @@ public class PostController {
 
 	// 5. 게시글 끌올 (로그인 필수)
 	@GetMapping("/{postId}/bump")
+	@Operation(summary = "게시글 끌올")
 	public BaseResponse<Void> bumpPost(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth) {
 		postService.bumpPost(postId, auth.getUserId());
 		return new BaseResponse<>();
@@ -51,6 +57,7 @@ public class PostController {
 	// - bumpedAt 가 있는 글이 먼저 우선적으로 내림차순으로 최근 끌올순 구현
 	// - bumpedAt 가 없는 글들 중에선 createdAt 순
 	@GetMapping
+	@Operation(summary = "게시글 전체 조회")
 	public BaseResponse<GetPostsResponse> getPosts(@RequestParam(required = false) Long lastPostId,
 		@RequestParam(defaultValue = "10") int size,
 		@RequestParam(required = false) Integer categoryId
@@ -64,6 +71,7 @@ public class PostController {
 
 	// 8. 좋아요 등록(토글) (로그인 필수)
 	@GetMapping("/{postId}/like")
+	@Operation(summary = "게시글 좋아요")
 	public BaseResponse<Void> toggleLike(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth) {
 		postService.toggleLike(postId, auth.getUserId());
 		return new BaseResponse<>();

--- a/src/main/java/org/glue/glue_be/setting/SecurityConfig.java
+++ b/src/main/java/org/glue/glue_be/setting/SecurityConfig.java
@@ -20,51 +20,51 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity
 public class SecurityConfig {
 
-	private final JwtAuthenticationFilter jwtAuthenticationFilter;
-	private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
-	private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
 
-	// 인증과정 배제 경로 -> 앞으로추가해나가야함
-	private static final String[] AUTH_WHITELIST = {
-		"/api/auth/kakao/signup"
-	};
+    // 인증과정 배제 경로 -> 앞으로추가해나가야함
+    private static final String[] AUTH_WHITELIST = {
+            "/api/auth/**",
+            "/swagger-ui/**",
+            "/api-docs/**"
+    };
 
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
-			.csrf(AbstractHttpConfigurer::disable)
-			.formLogin(form -> form.disable()) // 폼 로그인 비활성화
-			.sessionManagement(session -> {
-				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-			})
-			.exceptionHandling(exception -> {
-				exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
-				exception.accessDeniedHandler(customAccessDeniedHandler);
-			})
-		;
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+                .sessionManagement(session -> {
+                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                })
+                .exceptionHandling(exception -> {
+                    exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
+                    exception.accessDeniedHandler(customAccessDeniedHandler);
+                })
+        ;
 
-		http.authorizeHttpRequests(auth -> {
-			auth.requestMatchers(AUTH_WHITELIST).permitAll();
-//			auth.anyRequest().authenticated();
-			auth.anyRequest().permitAll(); // todo: 개발단계에선 일단 모든 경로에 허용, 원랜 화이트리스트의 경로만 적용해야함
-			})
-			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.authorizeHttpRequests(auth -> {
+                    auth.requestMatchers(AUTH_WHITELIST).permitAll();
+                    auth.anyRequest().authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
+        return http.build();
+    }
 
-		return http.build();
-	}
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
 
-	@Bean
-	public CorsConfigurationSource corsConfigurationSource() {
-		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.addAllowedOriginPattern("*");
-		configuration.addAllowedMethod("*");
-		configuration.addAllowedHeader("*");
-		configuration.setAllowCredentials(true);
-
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", configuration);
-		return source;
-	}
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 }

--- a/src/main/java/org/glue/glue_be/setting/SwaggerConfig.java
+++ b/src/main/java/org/glue/glue_be/setting/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package org.glue.glue_be.setting;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.*;
+import io.swagger.v3.oas.models.*;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.*;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    private final SwaggerServerProperties serverProperties;
+
+    @Bean
+    public OpenAPI openAPI() {
+        // API 기본 정보 설정
+        Info info = new Info()
+                .title("글루 API Document")
+                .version("1.0");
+
+        // JWT 인증 방식 설정
+        String jwtScheme = "jwtAuth";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtScheme);
+        Components components = new Components()
+                .addSecuritySchemes(jwtScheme, new SecurityScheme()
+                        .name("Authorization")
+                        .type(SecurityScheme.Type.HTTP)
+                        .in(SecurityScheme.In.HEADER)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT"));
+
+        // Swagger UI 설정 및 보안 추가
+        return new OpenAPI()
+                .components(components)
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .servers(serverProperties.getServerUrls());
+    }
+}

--- a/src/main/java/org/glue/glue_be/setting/SwaggerServerProperties.java
+++ b/src/main/java/org/glue/glue_be/setting/SwaggerServerProperties.java
@@ -1,0 +1,18 @@
+package org.glue.glue_be.setting;
+
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "swagger")
+public class SwaggerServerProperties {
+    private List<Server> serverUrls;
+
+    public void setServerUrls(List<Server> serverUrls) {
+        this.serverUrls = serverUrls;
+    }
+}

--- a/src/main/java/org/glue/glue_be/user/controller/UserController.java
+++ b/src/main/java/org/glue/glue_be/user/controller/UserController.java
@@ -1,6 +1,8 @@
 package org.glue.glue_be.user.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
+@Tag(name = "User", description = "유저 API")
 public class UserController {
 
 	private final UserService userService;
@@ -26,6 +29,7 @@ public class UserController {
 
 	// 1. 마이페이지 화면 정보 가져오기 => 닉네임, 한줄소개, 교환언어/수준 조회
 	@GetMapping("/my-page")
+	@Operation(summary = "마이페이지 정보")
 	public BaseResponse<GetMainPageInfoResponse> getMyPageInfo(@AuthenticationPrincipal CustomUserDetails auth ) {
 		GetMainPageInfoResponse response = userService.getMyPageInfo(auth.getUserId());
 		return new BaseResponse<>(response);
@@ -33,6 +37,7 @@ public class UserController {
 
 	//	// 2-1. 내 언어/수준 변경
 	@PutMapping("/main-language")
+	@Operation(summary = "내 언어/수준 변경")
 	public BaseResponse<Void> updateMainLanguage(@AuthenticationPrincipal CustomUserDetails auth, @Valid @RequestBody UpdateLanguageRequest request) {
 		userService.updateMainLanguage(auth.getUserId(), request);
 		return new BaseResponse<>();
@@ -40,6 +45,7 @@ public class UserController {
 
 	//	// 2-2. 학습 언어/수준 변경
 	@PutMapping("/learning-language")
+	@Operation(summary = "학습 언어/수준 변경")
 	public BaseResponse<Void> updateLearningLanguage(@AuthenticationPrincipal CustomUserDetails auth, @Valid @RequestBody UpdateLanguageRequest request) {
 		userService.updateLearningLanguage(auth.getUserId(), request);
 		return new BaseResponse<>();
@@ -47,6 +53,7 @@ public class UserController {
 
 	//	// 3. 프로필 조회 (본인)
 	@GetMapping("/profile/me")
+	@Operation(summary = "본인 프로필 조회")
 	public BaseResponse<MyProfileResponse> getMyProfile(@AuthenticationPrincipal CustomUserDetails auth) {
 		MyProfileResponse response = userService.getMyProfile(auth.getUserId());
 		return new BaseResponse<>(response);
@@ -54,6 +61,7 @@ public class UserController {
 
 	// 4. 프로필 조회 (타인)
 	@GetMapping("/profile/{userId}")
+	@Operation(summary = "타인 프로필 조회")
 	public BaseResponse<TargetProfileResponse> getUserProfile(@PathVariable Long userId, @AuthenticationPrincipal CustomUserDetails auth) {
 		 TargetProfileResponse response = userService.getTargetProfile(userId);
 		return new BaseResponse<>(response);
@@ -61,6 +69,7 @@ public class UserController {
 
 	// 5. 시스템 언어 변경
 	@PutMapping("/system-language")
+	@Operation(summary = "시스템 언어 변경")
 	public BaseResponse<Void> changeSystemLanguage(@AuthenticationPrincipal CustomUserDetails auth, @Valid @RequestBody ChangeSystemLanguageRequest request) {
 		userService.changeSystemLanguage(auth.getUserId(), request);
 		return new BaseResponse<>();
@@ -68,6 +77,7 @@ public class UserController {
 
 	// 6. 프로필 사진 변경
 	@PutMapping("/profile-image")
+	@Operation(summary = "프로필 사진 변경")
 	public BaseResponse<Void> updateProfileImage(@AuthenticationPrincipal CustomUserDetails auth, @RequestBody ChangeProfileImageRequest request) {
 		userService.changeProfileImage(auth.getUserId(), request);
 		return new BaseResponse<>();
@@ -76,6 +86,7 @@ public class UserController {
 	// 7. 학과 공개여부 설정
 	// 현재 visible 상태를 입력으로 받는다. db엔 !currentVisible을 저장하게됨
 	@PutMapping("/major-visibility")
+	@Operation(summary = "학과 공개여부 설정")
 	public BaseResponse<Void> setMajorVisibility(@AuthenticationPrincipal CustomUserDetails auth, @RequestParam int currentVisible) {
 		userService.setMajorVisibility(auth.getUserId(), currentVisible);
 		return new BaseResponse<>();
@@ -83,6 +94,7 @@ public class UserController {
 
 	// 8. 모임 히스토리 공개여부 설정
 	@PutMapping("/meeting-history-visibility")
+	@Operation(summary = "모임 히스토리 공개여부 설정")
 	public BaseResponse<Void> setMeetingHistoryVisibility(@AuthenticationPrincipal CustomUserDetails auth, @RequestParam int currentVisible) {
 		userService.setMeetingHistoryVisibility(auth.getUserId(), currentVisible);
 		return new BaseResponse<>();
@@ -90,6 +102,7 @@ public class UserController {
 
 	// 9. 좋아요 목록 공개여부 설정
 	@PutMapping("/like-list-visibility")
+	@Operation(summary = "좋아요 목록 공개여부 설정")
 	public BaseResponse<Void> setLikeListVisibility(
 		@AuthenticationPrincipal CustomUserDetails auth, @RequestParam int currentVisible) {
 		userService.setLikeListVisibility(auth.getUserId(), currentVisible);
@@ -98,6 +111,7 @@ public class UserController {
 
 	// 10. 방명록 공개여부 설정
 	@PutMapping("/guestbook-visibility")
+	@Operation(summary = "방명록 공개여부 설정")
 	public BaseResponse<Void> setGuestbookVisibility(@AuthenticationPrincipal CustomUserDetails auth, @RequestParam int currentVisible) {
 		userService.setGuestbookVisibility(auth.getUserId(), currentVisible);
 		return new BaseResponse<>();
@@ -105,6 +119,7 @@ public class UserController {
 
 	// 11. 공개 여부 정보 조회
 	@GetMapping("/visibility")
+	@Operation(summary = "공개 여부 옵션 목록 조회")
 	public BaseResponse<GetVisibilitiesResponse> getVisibilities(@AuthenticationPrincipal CustomUserDetails auth){
 		GetVisibilitiesResponse response = userService.getVisibilities(auth.getUserId());
 		return new BaseResponse<>(response);
@@ -112,6 +127,7 @@ public class UserController {
 
 	// 12. 모임 히스토리 조회
 	@GetMapping("/meetings-history")
+	@Operation(summary = "모임 히스토리 조회")
 	public BaseResponse<MeetingHistoryResponse> getMeetingHistory(@AuthenticationPrincipal CustomUserDetails auth, @RequestParam Long targetUserId) {
 		MeetingHistoryResponse response = userService.getMeetingHistory(auth.getUserId(), targetUserId);
 		return new BaseResponse<>(response);
@@ -119,6 +135,7 @@ public class UserController {
 
 	// 13. 좋아요 목록 조회
 	@GetMapping("/likes")
+	@Operation(summary = "좋아요 목록 조회")
 	public BaseResponse<GetLikedPostsResponse> getLikeList(
 		@AuthenticationPrincipal CustomUserDetails auth,  @RequestParam Long targetUserId) {
 		GetLikedPostsResponse response = userService.getLikeList(auth.getUserId(), targetUserId);
@@ -127,6 +144,7 @@ public class UserController {
 
 	// 14. 내 한줄소개 수정
 	@PostMapping("/description")
+	@Operation(summary = "한줄소개 수정")
 	public BaseResponse<Void> updateDescription(@AuthenticationPrincipal CustomUserDetails auth, @RequestBody UpdateDescriptionRequest request) {
 		userService.updateDescription(auth.getUserId(), request.description());
 		return new BaseResponse<>();

--- a/src/main/java/org/glue/glue_be/util/fcm/controller/FcmController.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/controller/FcmController.java
@@ -1,5 +1,7 @@
 package org.glue.glue_be.util.fcm.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.glue.glue_be.common.response.BaseResponse;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @Slf4j
 @RequestMapping("/api/fcm")
+@Tag(name = "FCM", description = "FCM 테스트용 API")
 public class FcmController {
 
     final FcmService fcmService;
@@ -23,6 +26,7 @@ public class FcmController {
 
     // 단일 기기로 fcm 발송
     @PostMapping("/single")
+    @Operation(summary = "단일 기기 FCM 발송 (테스트)")
     public BaseResponse<Void> sendSingle(@RequestBody @Valid FcmSendDto dto) {
         fcmService.sendMessage(dto);
         return new BaseResponse<>();
@@ -30,6 +34,7 @@ public class FcmController {
 
     // 여러 기기로 fcm 발송
     @PostMapping("/multi")
+    @Operation(summary = "다중 기기 FCM 발송 (테스트)")
     public BaseResponse<Void> sendMulti(@RequestBody @Valid MultiFcmSendDto dto) {
         fcmService.sendMultiMessage(dto);
         return new BaseResponse<>();


### PR DESCRIPTION
### 주요 변경 사항
- Swagger 설정 파일(`SwaggerConfig`, `SwaggerServerProperties`) 추가
- 인증 예외 경로 설정
  - `/api/auth/**`, `/swagger-ui/**`, `/api-docs/**` 등 인증 없이 접근 가능하도록 설정
  - 그 외 모든 경로는 JWT 인증 필요
- Swagger 문서 어노테이션 추가
  - 컨트롤러에 `@Tag`, `@Operation` 어노테이션 적용


<img width="316" alt="스크린샷 2025-05-27 오후 8 31 42" src="https://github.com/user-attachments/assets/eccceb70-b402-4a5f-b779-a6b48880232e" />

- 위 버튼을 통해 **운영 서버 문서로도 접근 가능**합니다.


closes #85 