### PR TITLE
fix: 실시간 읽음 처리를 위한 Redis 도입기(1) - 임시 해결책: DB 기반 읽음 처리

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/dto/response/GroupMessageResponse.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/GroupMessageResponse.java
@@ -9,7 +9,6 @@ public record GroupMessageResponse(
         Long groupChatroomId,
         UserSummary sender,
         String message,
-        Integer unreadCount,
         LocalDateTime createdAt
 ) {
     // Static builder method to maintain compatibility with builder pattern
@@ -23,7 +22,6 @@ public record GroupMessageResponse(
         private Long groupChatroomId;
         private UserSummary sender;
         private String message;
-        private Integer unreadCount;
         private LocalDateTime createdAt;
 
         public Builder groupMessageId(Long groupMessageId) {
@@ -46,11 +44,6 @@ public record GroupMessageResponse(
             return this;
         }
 
-        public Builder unreadCount(Integer unreadCount) {
-            this.unreadCount = unreadCount;
-            return this;
-        }
-
         public Builder createdAt(LocalDateTime createdAt) {
             this.createdAt = createdAt;
             return this;
@@ -62,7 +55,6 @@ public record GroupMessageResponse(
                     groupChatroomId,
                     sender,
                     message,
-                    unreadCount,
                     createdAt
             );
         }

--- a/src/main/java/org/glue/glue_be/chat/entity/dm/DmMessage.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/dm/DmMessage.java
@@ -29,19 +29,6 @@ public class DmMessage extends BaseEntity {
 	@Column(name = "dm_message_content", columnDefinition = "TEXT", nullable = false)
 	private String dmMessageContent;
 
-	@Column(name = "is_read", nullable = false)
-	@ColumnDefault("0")
-	private int isRead;
-
-	// isRead를 boolean으로 바꾸기 (repository에서 쉽게 사용하게 하기 위함)
-	public boolean isRead() {
-		return isRead == 1;
-	}
-
-	public void setIsRead(int isRead) {
-		this.isRead = isRead;
-	}
-
 	@Builder
 	private DmMessage(DmChatRoom chatRoom, User user, String dmMessageContent){
 		this.dmChatRoom = chatRoom;

--- a/src/main/java/org/glue/glue_be/chat/entity/dm/DmUserChatroom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/dm/DmUserChatroom.java
@@ -27,6 +27,9 @@ public class DmUserChatroom extends BaseEntity {
 	@Column(name = "push_notification_on", nullable = false)
 	private Integer pushNotificationOn = 1;
 
+	@Column(name = "last_read_message_id")
+	private Long lastReadMessageId = 0L;
+
 	@Builder
 	private DmUserChatroom(User user, DmChatRoom dmChatRoom){
 		this.user = user;

--- a/src/main/java/org/glue/glue_be/chat/entity/group/GroupMessage.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/group/GroupMessage.java
@@ -36,19 +36,12 @@ public class GroupMessage extends BaseEntity {
     @Column(name = "message_content")
     private String message;
 
-    @Column(name = "unread_count")
-    private Integer unreadCount;
-
     // Constructor with required fields
-    public GroupMessage(User user, GroupChatRoom groupChatroom, Meeting meeting, String message, Integer unreadCount) {
+    public GroupMessage(User user, GroupChatRoom groupChatroom, Meeting meeting, String message) {
         this.user = user;
         this.groupChatroom = groupChatroom;
         this.meeting = meeting;
         this.message = message;
-        this.unreadCount = (unreadCount == null) ? UNREAD_COUNT_DEFAULT: unreadCount;
     }
 
-    public void updateUnreadCount() {
-        this.unreadCount -= 1;
-    }
 }

--- a/src/main/java/org/glue/glue_be/chat/entity/group/GroupUserChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/group/GroupUserChatRoom.java
@@ -25,6 +25,9 @@ public class GroupUserChatRoom extends BaseEntity {
     @JoinColumn(name = "group_chatroom_id")
     private GroupChatRoom groupChatroom;
 
+    @Column(name = "last_read_message_id")
+    private Long lastReadMessageId = 0L;
+
     private Integer pushNotificationOn = 1;
 
     // Constructor with required fields

--- a/src/main/java/org/glue/glue_be/chat/mapper/DmResponseMapper.java
+++ b/src/main/java/org/glue/glue_be/chat/mapper/DmResponseMapper.java
@@ -11,7 +11,6 @@ import org.glue.glue_be.user.entity.User;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -91,7 +90,6 @@ public class DmResponseMapper {
                         .build())
                 .content(dmMessage.getDmMessageContent())
                 .createdAt(dmMessage.getCreatedAt())
-                .isRead(dmMessage.getIsRead())
                 .build();
     }
 }

--- a/src/main/java/org/glue/glue_be/chat/mapper/GroupResponseMapper.java
+++ b/src/main/java/org/glue/glue_be/chat/mapper/GroupResponseMapper.java
@@ -116,7 +116,6 @@ public class GroupResponseMapper {
                 .groupChatroomId(message.getGroupChatroom().getGroupChatroomId())
                 .sender(senderSummary)
                 .message(message.getMessage())
-                .unreadCount(message.getUnreadCount())
                 .createdAt(message.getCreatedAt())
                 .build();
     }

--- a/src/main/java/org/glue/glue_be/chat/repository/dm/DmMessageRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/dm/DmMessageRepository.java
@@ -18,11 +18,6 @@ public interface DmMessageRepository extends JpaRepository<DmMessage, Long> {
 
     Optional<DmMessage> findTopByDmChatRoomOrderByCreatedAtDesc(DmChatRoom chatRoom);
 
-    boolean existsByDmChatRoomAndUser_UserIdNotAndIsRead(DmChatRoom dmChatRoom, Long userId, int isRead);
-
-    @Query("SELECT m FROM DmMessage m WHERE m.dmChatRoom.id = :chatRoomId AND m.user.userId != :userId AND m.isRead = 0")
-    List<DmMessage> findUnreadMessages(@Param("chatRoomId") Long chatRoomId, @Param("userId") Long userId);
-
     // 커서 기반 메시지 조회를 위한 새로운 메서드들 (id 필드 사용)
     // 첫 번째 요청 (cursorId가 null일 때) - 최신 메시지부터 내림차순
     List<DmMessage> findByDmChatRoomOrderByIdDesc(DmChatRoom dmChatRoom, Pageable pageable);

--- a/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
@@ -5,6 +5,7 @@ import org.glue.glue_be.chat.entity.dm.DmUserChatroom;
 import org.glue.glue_be.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -38,4 +39,13 @@ public interface DmUserChatroomRepository extends JpaRepository<DmUserChatroom, 
             @Param("user") User user,
             @Param("cursorId") Long cursorId,
             Pageable pageable);
+
+    DmChatRoom findByUser_UserIdAndDmChatRoom_id(Long userId, Long dmChatRoomId);
+
+    @Modifying
+    @Query("UPDATE DmUserChatroom du SET du.lastReadMessageId = :messageId " +
+            "WHERE du.user.userId = :userId AND du.dmChatRoom.id = :dmChatroomId")
+    void updateLastReadMessageId(@Param("userId") Long userId,
+                                 @Param("groupChatroomId") Long dmChatroomId,
+                                 @Param("messageId") Long messageId);
 }

--- a/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
@@ -21,31 +21,26 @@ public interface DmUserChatroomRepository extends JpaRepository<DmUserChatroom, 
 
     Optional<DmUserChatroom> findByDmChatRoomAndUser(DmChatRoom dmChatRoom, User sender);
 
-    @Query("SELECT ducr.dmChatRoom FROM DmUserChatroom ducr WHERE ducr.user.userId = :userId")
-    List<DmChatRoom> findDmChatRoomsByUserId(@Param("userId") Long userId);
+    @Query(value = "SELECT DISTINCT dc.* FROM dm_chatroom dc " +
+            "JOIN dm_user_chatroom duc ON dc.dm_chatroom_id = duc.dm_chatroom_id " +
+            "WHERE duc.user_id = :userId " +
+            "ORDER BY dc.dm_chatroom_id DESC",
+            nativeQuery = true)
+    List<DmChatRoom> findDmChatRoomsByUserOrderByDmChatRoomIdDesc(@Param("userId") Long userId, Pageable pageable);
 
-    @Query("SELECT duc.dmChatRoom FROM DmUserChatroom duc " +
-            "WHERE duc.user = :user " +
-            "ORDER BY duc.dmChatRoom.id DESC")
-    List<DmChatRoom> findDmChatRoomsByUserOrderByDmChatRoomIdDesc(
-            @Param("user") User user,
-            Pageable pageable);
+    @Query(value = "SELECT DISTINCT dc.* FROM dm_chatroom dc " +
+            "JOIN dm_user_chatroom duc ON dc.dm_chatroom_id = duc.dm_chatroom_id " +
+            "WHERE duc.user_id = :userId AND dc.dm_chatroom_id < :cursorId " +
+            "ORDER BY dc.dm_chatroom_id DESC",
+            nativeQuery = true)
+    List<DmChatRoom> findDmChatRoomsByUserAndDmChatRoomIdLessThanOrderByDmChatRoomIdDesc(@Param("userId") Long userId, @Param("cursorId") Long cursorId, Pageable pageable);
 
-    @Query("SELECT duc.dmChatRoom FROM DmUserChatroom duc " +
-            "WHERE duc.user = :user " +
-            "AND duc.dmChatRoom.id < :cursorId " +
-            "ORDER BY duc.dmChatRoom.id DESC")
-    List<DmChatRoom> findDmChatRoomsByUserAndDmChatRoomIdLessThanOrderByDmChatRoomIdDesc(
-            @Param("user") User user,
-            @Param("cursorId") Long cursorId,
-            Pageable pageable);
-
-    DmChatRoom findByUser_UserIdAndDmChatRoom_id(Long userId, Long dmChatRoomId);
+    Optional<DmUserChatroom> findByUser_UserIdAndDmChatRoom_Id(Long userId, Long dmChatRoomId);
 
     @Modifying
     @Query("UPDATE DmUserChatroom du SET du.lastReadMessageId = :messageId " +
             "WHERE du.user.userId = :userId AND du.dmChatRoom.id = :dmChatroomId")
     void updateLastReadMessageId(@Param("userId") Long userId,
-                                 @Param("groupChatroomId") Long dmChatroomId,
+                                 @Param("dmChatroomId") Long dmChatroomId,
                                  @Param("messageId") Long messageId);
 }

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupMessageRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupMessageRepository.java
@@ -18,13 +18,6 @@ public interface GroupMessageRepository extends JpaRepository<GroupMessage, Long
     // 채팅방의 가장 최근 메시지 조회
     Optional<GroupMessage> findTopByGroupChatroomOrderByCreatedAtDesc(GroupChatRoom groupChatroom);
 
-    // 읽지 않은 메시지 존재 여부 확인
-    boolean existsByGroupChatroomAndUser_UserIdNotAndUnreadCount(GroupChatRoom groupChatroom, Long userId, Integer isRead);
-
-    // 읽지 않은 메시지 조회
-    @Query("SELECT gm FROM GroupMessage gm WHERE gm.groupChatroom.groupChatroomId = :groupChatroomId AND gm.user.userId != :userId AND gm.unreadCount != 0")
-    List<GroupMessage> findUnreadMessages(@Param("groupChatroomId") Long groupChatroomId, @Param("userId") Long userId);
-
     // 커서 기반 메시지 조회를 위한 새로운 메서드들
     // 첫 번째 요청 (cursorId가 null일 때) - 최신 메시지부터 내림차순
     List<GroupMessage> findByGroupChatroomOrderByGroupMessageIdDesc(GroupChatRoom groupChatroom, Pageable pageable);

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupUserChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupUserChatRoomRepository.java
@@ -4,6 +4,9 @@ import org.glue.glue_be.chat.entity.group.GroupChatRoom;
 import org.glue.glue_be.chat.entity.group.GroupUserChatRoom;
 import org.glue.glue_be.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,9 +19,15 @@ public interface GroupUserChatRoomRepository extends JpaRepository<GroupUserChat
     // 채팅방의 모든 참여자 조회
     List<GroupUserChatRoom> findByGroupChatroom(GroupChatRoom groupChatroom);
 
-    // 유저가 참여한 모든 채팅방 조회
-    List<GroupUserChatRoom> findByUser(User user);
-
     // 채팅방과 유저로 삭제
     void deleteByGroupChatroomAndUser(GroupChatRoom groupChatroom, User user);
+
+    Optional<GroupUserChatRoom> findByUser_UserIdAndGroupChatroom_GroupChatroomId(Long userId, Long groupChatroomId);
+
+    @Modifying
+    @Query("UPDATE GroupUserChatRoom g SET g.lastReadMessageId = :messageId " +
+            "WHERE g.user.userId = :userId AND g.groupChatroom.groupChatroomId = :groupChatroomId")
+    void updateLastReadMessageId(@Param("userId") Long userId,
+                                 @Param("groupChatroomId") Long groupChatroomId,
+                                 @Param("messageId") Long messageId);
 }

--- a/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
@@ -374,48 +374,6 @@ public abstract class CommonChatService {
         }
     }
 
-    protected <M, C, UC> void sendPushNotificationToUser(
-            M message,
-            Long recipientId,
-            C chatRoom,
-            Function<C, Long> chatRoomIdExtractor,              // 추가: 채팅방 ID 추출
-            Function<M, String> contentExtractor,
-            Function<M, User> senderExtractor,
-            BiFunction<Long, Long, Optional<UC>> userChatRoomFinder, // userId, chatRoomId -> UserChatRoom
-            Function<UC, Integer> notificationSettingGetter,
-            String notificationTitle) {
-
-        // 채팅방 ID 추출
-        Long chatRoomId = chatRoomIdExtractor.apply(chatRoom);
-
-        // 알림 설정 확인
-        Optional<UC> userChatRoom = userChatRoomFinder.apply(recipientId, chatRoomId);
-
-        if (userChatRoom.isEmpty() || notificationSettingGetter.apply(userChatRoom.get()) != 1) {
-            return; // 알림 설정이 꺼져있음
-        }
-
-        User recipient = getUserById(recipientId);
-        if (recipient.getFcmToken() == null) {
-            return; // FCM 토큰이 없음
-        }
-
-        String content = contentExtractor.apply(message);
-        if (content.length() > 100) {
-            content = content.substring(0, 97) + "...";
-        }
-
-        User sender = senderExtractor.apply(message);
-
-        FcmSendDto fcmDto = FcmSendDto.builder()
-                .title(sender.getNickname() + notificationTitle)
-                .body(content)
-                .token(recipient.getFcmToken())
-                .build();
-
-        fcmService.sendMessage(fcmDto);
-    }
-
     protected User getUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException.UserNotFoundException(userId));

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -245,8 +245,8 @@ public class DmChatService extends CommonChatService {
                     pageSize,
                     userId,
                     this::getUserById,
-                    dmUserChatroomRepository::findDmChatRoomsByUserOrderByDmChatRoomIdDesc,
-                    dmUserChatroomRepository::findDmChatRoomsByUserAndDmChatRoomIdLessThanOrderByDmChatRoomIdDesc,
+                    (user, pageable) -> dmUserChatroomRepository.findDmChatRoomsByUserOrderByDmChatRoomIdDesc(user.getUserId(), pageable),
+                    (user, curId, pageable) -> dmUserChatroomRepository.findDmChatRoomsByUserAndDmChatRoomIdLessThanOrderByDmChatRoomIdDesc(user.getUserId(), curId, pageable),
                     (chatRooms, user) -> {
                         // 내가 호스트가 아닌 미팅의 DM 채팅방만 필터링 후 변환
                         List<DmChatRoom> filteredChatRooms = chatRooms.stream()
@@ -499,7 +499,9 @@ public class DmChatService extends CommonChatService {
 
     private Long getCurrentUserLastReadMessageId(Long userId, Long chatroomId) {
         return dmUserChatroomRepository
-                .findByUser_UserIdAndDmChatRoom_id(userId, chatroomId).getId();
+                .findByUser_UserIdAndDmChatRoom_Id(userId, chatroomId)  // Repository 메소드명 수정
+                .map(DmUserChatroom::getLastReadMessageId)              // getId() -> getLastReadMessageId()
+                .orElse(0L);                                            // Optional 처리
     }
 
     private Long getLatestMessageId(DmChatRoom chatRoom) {

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -278,8 +278,14 @@ public class DmChatService extends CommonChatService {
                     DmMessage lastMessage = dmMessageRepository.findTopByDmChatRoomOrderByCreatedAtDesc(chatRoom)
                             .orElse(null);
 
-                    boolean hasUnreadMessages = dmMessageRepository.existsByDmChatRoomAndUser_UserIdNotAndIsRead(
-                            chatRoom, currentUser.getUserId(), 0);
+                    // 현재 사용자의 마지막 읽은 메시지 ID 조회
+                    Long currentUserLastReadMessageId = getCurrentUserLastReadMessageId(currentUser.getUserId(), chatRoom.getId());
+
+                    // 채팅방의 가장 최신 메시지 ID 조회
+                    long latestMessageId = getLatestMessageId(chatRoom);
+
+                    // 읽지 않은 메시지 여부 확인
+                    boolean hasUnreadMessages = currentUserLastReadMessageId < latestMessageId;
 
                     return responseMapper.toChatRoomListResponse(
                             chatRoom, otherUser, lastMessage, hasUnreadMessages);
@@ -349,10 +355,8 @@ public class DmChatService extends CommonChatService {
                     userId,
                     this::getChatRoomById,
                     this::validateChatRoomMember,
-                    dmMessageRepository::findUnreadMessages,
-                    message -> message.setIsRead(1),
-                    dmMessageRepository::saveAll,
-                    this::notifyDmMessageRead
+                    this::getLatestMessageId,
+                    dmUserChatroomRepository::updateLastReadMessageId
             );
         } catch (BaseException e) {
             throw e;
@@ -361,7 +365,8 @@ public class DmChatService extends CommonChatService {
         }
     }
 
-    // 웹소켓에 연결되어 있을 때 메시지를 읽었다는 정보를 실시간으로 전달
+    // 메시지 읽음 알림 전송(푸시 알림 아님, 실시간 알림)
+    // TODO: 레디스 도입하며 아마 함께 사용하게 될 메소드 (현재 사용 x)
     private void notifyDmMessageRead(Long dmChatRoomId, Long receiverId, List<DmMessage> readMessages) {
         if (!readMessages.isEmpty()) {
             DmChatRoomDetailResponse chatRoom = getDmChatRoomDetail(dmChatRoomId);
@@ -389,10 +394,11 @@ public class DmChatService extends CommonChatService {
     @Transactional
     public DmMessageResponse processDmMessage(Long dmChatRoomId, DmMessageSendRequest request, Long userId) {
         try {
-            // 1. 메시지 저장
+            // 메시지 db에 저장
             DmMessageResponse response = saveDmMessage(dmChatRoomId, userId, request.getContent());
 
-            // 2. 메시지 전송 관리(온라인-웹소켓, 오프라인-푸시알림)
+            // 메시지 전송 및 알림
+            // 온라인: 웹소켓으로, 오프라인: 푸시알림으로
             broadcastMessage(dmChatRoomId, response, userId);
 
             return response;
@@ -429,44 +435,47 @@ public class DmChatService extends CommonChatService {
     }
 
     // 알림 전송: 웹소켓(실시간) + 푸시(비실시간)
-    private void broadcastMessage(Long dmChatRoomId, DmMessageResponse messageResponse, Long senderId) {
+    private void broadcastMessage(Long chatroomId, DmMessageResponse messageResponse, Long senderId) {
         try {
-            // 채팅방 정보 가져오기
-            DmChatRoomDetailResponse chatRoom = getDmChatRoomDetail(dmChatRoomId);
+            DmChatRoom dmChatRoom = getChatRoomById(chatroomId);
+            Optional<DmMessage> messageOpt = dmMessageRepository.findById(messageResponse.getDmMessageId());
 
-            // 1. 모든 참여자에게 웹소켓으로 메시지 전송 시도 (온라인 상태인 참여자만 받게 됨)
-            // sendWebSocketMessageToOnlineReceivers 내부의 convertAndSend() 매소드가 연결 상태를 자체적으로 확인한다!
-            sendWebSocketMessageToOnlineReceivers(
-                    chatRoom.getParticipants(),
-                    senderId,
-                    "/queue/dm/",
-                    messageResponse,
-                    UserSummary::getUserId
-            );
+            if (messageOpt.isEmpty()) {
+                throw new BaseException(ChatResponseStatus.MESSAGE_NOT_FOUND);
+            }
 
-            // 2. 오프라인 참여자에게 푸시 알림 전송
-            DmChatRoom dmChatRoom = getChatRoomById(dmChatRoomId);
-            DmMessage message = dmMessageRepository.findById(messageResponse.getDmMessageId())
-                    .orElseThrow(() -> new BaseException(ChatResponseStatus.MESSAGE_NOT_FOUND));
+            DmMessage message = messageOpt.get();
+            DmChatRoomDetailResponse chatRoom = getDmChatRoomDetail(chatroomId, Optional.ofNullable(senderId));
 
-            // 이 매소드 내부에서 조건 필터링
+            // 모든 참여자에게 웹소켓 전송
+            // 웹소켓에 연결된 사용자만 실제 수신
+            // 오프라인 수신자는 받지도 않고 에러를 내지도 않고 그냥 무시
+            for (UserSummary participant : chatRoom.getParticipants()) {
+                Long participantId = participant.getUserId();
+
+                if (!participantId.equals(senderId)) {
+                    messagingTemplate.convertAndSend("/queue/dm/" + participantId, messageResponse);
+                }
+            }
+
+            // 모든 오프라인 참여자에게 푸시 알림 전송
             sendPushNotificationsToOfflineReceivers(
                     message,
                     dmChatRoom,
                     senderId,
                     "/queue/dm",
-                    DmMessage::getDmMessageContent,                      // 메시지 내용 추출
-                    DmMessage::getUser,                                  // 발신자 정보 추출
-                    dmUserChatroomRepository::findByDmChatRoom,          // 참여자 목록 조회
-                    DmUserChatroom::getUser,                             // 사용자 정보 추출
-                    DmUserChatroom::getPushNotificationOn,               // 알림 설정 조회
-                    this::isUserConnectedToWebSocket,                    // 웹소켓 연결 확인
-                    (sender, recipient, content) -> FcmSendDto.builder() // 알림 객체 생성
-                            .title(sender.getNickname() + "님의 메시지")
+                    DmMessage::getDmMessageContent,
+                    DmMessage::getUser,
+                    dmUserChatroomRepository::findByDmChatRoom,
+                    DmUserChatroom::getUser,
+                    DmUserChatroom::getPushNotificationOn,
+                    this::isUserConnectedToWebSocket,
+                    (sender, recipient, content) -> FcmSendDto.builder()
+                            .title(sender.getNickname() + "님의 쪽지")
                             .body(content)
                             .token(recipient.getFcmToken())
                             .build(),
-                    fcmService::sendMessage                              // 알림 전송
+                    fcmService::sendMessage
             );
         } catch (BaseException e) {
             throw e;
@@ -486,6 +495,17 @@ public class DmChatService extends CommonChatService {
     private DmUserChatroom validateChatRoomMember(DmChatRoom chatRoom, User user) {
         return dmUserChatroomRepository.findByDmChatRoomAndUser(chatRoom, user)
                 .orElseThrow(() -> new BaseException(ChatResponseStatus.USER_NOT_MEMBER));
+    }
+
+    private Long getCurrentUserLastReadMessageId(Long userId, Long chatroomId) {
+        return dmUserChatroomRepository
+                .findByUser_UserIdAndDmChatRoom_id(userId, chatroomId).getId();
+    }
+
+    private Long getLatestMessageId(DmChatRoom chatRoom) {
+        DmMessage lastMessage = dmMessageRepository.findTopByDmChatRoomOrderByCreatedAtDesc(chatRoom)
+                .orElse(null);
+        return lastMessage != null ? lastMessage.getId() : 0L;
     }
 
     @Override

--- a/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
@@ -343,23 +343,21 @@ public class GroupChatService extends CommonChatService {
     // 메시지 db에 저장
     private GroupMessageResponse saveGroupMessage(Long groupChatroomId, Long senderId, String content) {
         try {
-            GroupChatRoom groupChatRoom = getChatRoomById(groupChatroomId);
-            User sender = getUserById(senderId);
-            validateChatRoomMember(groupChatRoom, sender);
-
-            // 메시지 생성
-            GroupMessage groupMessage = new GroupMessage(
-                    sender,
-                    groupChatRoom,
-                    groupChatRoom.getMeeting(),
-                    content
+            return saveMessage(
+                    groupChatroomId,
+                    senderId,
+                    content,
+                    this::getChatRoomById,
+                    this::validateChatRoomMember,
+                    (chatRoom, sender, messageContent) -> new GroupMessage(
+                            sender,
+                            chatRoom,
+                            chatRoom.getMeeting(),
+                            messageContent
+                    ),
+                    groupMessageRepository::save,
+                    responseMapper::toMessageResponse
             );
-
-            // 메시지 저장
-            GroupMessage savedMessage = groupMessageRepository.save(groupMessage);
-
-            // 응답 생성
-            return responseMapper.toMessageResponse(savedMessage);
         } catch (BaseException e) {
             throw e;
         } catch (Exception e) {


### PR DESCRIPTION
- 컨트롤러는 건드리지 않아 가현님과 스태시 일어나진 않을 겁니당.
---
## 개요
기존 메시지별 unreadCount 저장 방식에서 사용자별 lastReadMessageId 저장 방식으로 변경하여 동시성 문제를 해결하고, 향후 Redis 도입을 위한 기반을 마련했습니다.

## 이전의 문제 사항: 메시지마다 unreadCount를 저장
### 1. 동시성 문제 
```
public void markAsRead(Long messageId) {
  GroupMessage message = findById(messageId);
  message.setUnreadCount(message.getUnreadCount() - 1); // 동시에 여러 명이 읽으면?
  save(message);
}
```
- 여러 사용자가 동시에 같은 메시지를 읽을 때 Race Condition이 발생했습니다. (어리석게도 고려하지 못하고 테스트하며 에러 터지고 나서 알게 된 문제..)

### 2. 그룹 멤버 변동 시 복잡성
- 새 멤버가 들어오면 기존 모든 메시지의 unreadCount를 +1 해야 함
- 멤버가 나가면 모든 메시지의 unreadCount를 -1 해야 함

### 3. 그룹 채팅에서 누가 읽었는지 추적이 불가능함
- 메시지별 unreadCount로는 "누가 읽었는지"를 알 수 없어서 실시간으로 읽음 표시를 업데이트할 수 없었습니다.

## 주요 변경 사항
- 프로젝트 데드라인이 코앞이었기 때문에 Redis를 당장 도입할 수는 없었다고 판단했습니다. (생각할 게 생각보다 너무 많더군요.)
- 대신 추후 redis를 도입하기 쉽도록, 그리고 가장 중요한 동시성 문제가 발생하지 않도록 db 수준에서의 해결책을 모색했습니다.
### 1. 데이터베이스 스키마 변경
- GroupMessage 테이블에서 unreadCount 컬럼 제거, DmMessage 테이블에서 isRead 컬럼 제거
- GroupUserChatRoom와 DmUserChatroom 테이블에 lastReadMessageId 컬럼 추가 (기본값: 0)
### 2. 읽음 처리 로직 개선
- Before: 메시지별 읽지 않은 사용자 수 저장
- After: 사용자별 마지막 읽은 메시지 ID 저장
### 3. 푸시 알림 로직 최적화
- 웹소켓 연결 상태 기반으로 푸시 알림 여부 결정
- 온라인 사용자: 웹소켓으로만 메시지 전송
- 오프라인 사용자: FCM 푸시 알림 전송

## 해결된 문제점
### 1. 동시성 문제 해결 
- 사용자별 독립적인 읽음 상태 관리 =>  Race Condition 완전 제거
### 2. 그룹 멤버 변동 시 복잡성 해결
- 새 멤버 추가/제거 시 기존 메시지 수정 불필요
- lastReadMessageId = 0으로 초기화하면 모든 메시지가 안읽음 상태
### 3. Redis 도입 위한 확장성 확보
- Redis 도입 시 최소한의 코드 변경으로 마이그레이션 가능
- 실시간 읽음 표시 기능 추가 준비 완료

## 향후 계획
- 최초 출시 전: 회원 탈퇴 로직 추가
- 출시 이후: Redis 도입을 통한 실시간 읽음 상태 처리

close #87 