### PR TITLE
게시글 기능 추가 구현 및 기획 변경분 반영 + 버그수정

### DIFF
--- a/src/main/java/org/glue/glue_be/auth/controller/AuthController.java
+++ b/src/main/java/org/glue/glue_be/auth/controller/AuthController.java
@@ -32,4 +32,17 @@ public class AuthController {
 		return new BaseResponse<>(true);
 	}
 
+	@GetMapping("/nickname/{nickname}")
+	BaseResponse<Boolean> nickname(@PathVariable("nickname") String nickname) {
+		authService.checkNickname(nickname);
+		return new BaseResponse<>(true);
+	}
+
+	@GetMapping("/email/{email}")
+	BaseResponse<Boolean> nickEmail(@PathVariable("email") String email) {
+		authService.checkEmail(email);
+		return new BaseResponse<>(true);
+	}
+
+
 }

--- a/src/main/java/org/glue/glue_be/auth/service/AuthService.java
+++ b/src/main/java/org/glue/glue_be/auth/service/AuthService.java
@@ -171,4 +171,17 @@ public class AuthService {
 
     }
 
+
+    // 닉네임 중복체크(중복말고도 추후 적절한 닉넴 검증등에 대한 추가 로직이 들어올수도 있단 생각에 일반화된 네이밍 사용)
+	public void checkNickname(String nickname) {
+        if(userRepository.existsByNickname(nickname))
+            throw new BaseException(UserResponseStatus.ALREADY_EXISTS, "중복된 닉네임입니다.");
+    }
+
+
+    public void checkEmail(String email) {
+        if(userRepository.existsByEmail(email))
+            throw new BaseException(UserResponseStatus.ALREADY_EXISTS, "중복된 이메일입니다.");
+    }
+
 }

--- a/src/main/java/org/glue/glue_be/chat/repository/dm/DmChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/dm/DmChatRoomRepository.java
@@ -31,4 +31,7 @@ public interface DmChatRoomRepository extends JpaRepository<DmChatRoom, Long> {
 
     // 호스트 기준 커서 조회
     List<DmChatRoom> findByMeetingHostAndIdLessThanOrderByIdDesc(User host, Long cursorId, Pageable pageable);
+
+	List<DmChatRoom> findByMeeting_MeetingId(Long meetingMeetingId);
+
 }

--- a/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
@@ -38,4 +38,7 @@ public interface DmUserChatroomRepository extends JpaRepository<DmUserChatroom, 
             @Param("user") User user,
             @Param("cursorId") Long cursorId,
             Pageable pageable);
+
+	void deleteByDmChatRoom_Id(Long dmChatRoomId);
+
 }

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupChatRoomRepository.java
@@ -15,9 +15,11 @@ import org.springframework.data.domain.Pageable;
 
 public interface GroupChatRoomRepository extends JpaRepository<GroupChatRoom, Long> {
 
-    // 미팅 ID로 그룹 채팅방 조회
-    Optional<GroupChatRoom> findByMeeting_MeetingId(Long meetingId);
+    // 미팅 ID로 그룹 채팅방 리스트 조회
+    List<GroupChatRoom> findByMeeting_MeetingId(Long meetingId);
 
+    // meeting_id fk로 첫번째 그룹 단톡방 가져오기 (지금 서비스 플로우에선 사실상 일대일 관계이긴함)
+    Optional<GroupChatRoom> findFirstByMeeting_MeetingId(Long meetingId);
 
     @Query("SELECT DISTINCT gc FROM GroupChatRoom gc " +
             "JOIN gc.groupUserChatrooms guc " +
@@ -34,4 +36,7 @@ public interface GroupChatRoomRepository extends JpaRepository<GroupChatRoom, Lo
             @Param("user") User user,
             @Param("cursorId") Long cursorId,
             Pageable pageable);
+    boolean existsByMeeting_MeetingId(Long meetingMeetingId);
+
+
 }

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupMessageRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupMessageRepository.java
@@ -34,4 +34,7 @@ public interface GroupMessageRepository extends JpaRepository<GroupMessage, Long
             GroupChatRoom groupChatroom,
             Long cursorId,
             Pageable pageable);
+
+	void deleteByGroupChatroom_GroupChatroomId(Long roomId);
+
 }

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupUserChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupUserChatRoomRepository.java
@@ -21,4 +21,7 @@ public interface GroupUserChatRoomRepository extends JpaRepository<GroupUserChat
 
     // 채팅방과 유저로 삭제
     void deleteByGroupChatroomAndUser(GroupChatRoom groupChatroom, User user);
+
+	void deleteByGroupChatroom_GroupChatroomId(Long roomId);
+
 }

--- a/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
@@ -48,12 +48,12 @@ public class GroupChatService extends CommonChatService {
 
             User user = getUserById(userId);
 
-            // 기존에 해당 미팅에 대한 그룹 채팅방이 있는지 확인
-            Optional<GroupChatRoom> existingChatRoom = groupChatRoomRepository.findByMeeting_MeetingId(meetingId);
-
-            if (existingChatRoom.isPresent()) {
+            // 기존에 해당 미팅에 대한 그룹 채팅방이 있는지 여부에 따라 로직 처리가 다르게 됨
+            if (groupChatRoomRepository.existsByMeeting_MeetingId(meetingId)) {
                 // 기존 채팅방이 있으면 사용자만 추가
-                GroupChatRoom chatRoom = existingChatRoom.get();
+                GroupChatRoom chatRoom = groupChatRoomRepository
+                    .findFirstByMeeting_MeetingId(meetingId)
+                    .orElseThrow(() -> new BaseException(ChatResponseStatus.CHATROOM_NOT_FOUND));
 
                 // 이미 사용자가 채팅방에 참여 중인지 확인
                 Optional<GroupUserChatRoom> existingUserChatroom =

--- a/src/main/java/org/glue/glue_be/invitation/repository/InvitationRepository.java
+++ b/src/main/java/org/glue/glue_be/invitation/repository/InvitationRepository.java
@@ -36,4 +36,7 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
             @Param("meetingId") Long meetingId,
             @Param("creatorUserId") Long creatorUserId,
             @Param("inviteeUserId") Long inviteeUserId);
-} 
+
+	void deleteByMeeting_MeetingId(Long meetingMeetingId);
+
+}

--- a/src/main/java/org/glue/glue_be/meeting/dto/MeetingDto.java
+++ b/src/main/java/org/glue/glue_be/meeting/dto/MeetingDto.java
@@ -36,17 +36,24 @@ public class MeetingDto {
         @NotBlank(message = "모임 장소는 필수입니다")
         private String meetingPlaceName;
 
-        private Double meetingPlaceLatitude;
-        private Double meetingPlaceLongitude;
-
-        @NotNull(message = "최소 인원은 필수입니다")
-        @Min(value = 1, message = "최소 인원은 1명 이상이어야 합니다")
-        private Integer minPpl;
-
         @NotNull(message = "최대 인원은 필수입니다")
         @Max(value = 100, message = "최대 인원은 100명을 초과할 수 없습니다")
-        private Integer maxPpl;
+        private Integer maxParticipants;
+
+        @NotNull
+        private Integer categoryId;
+
+        @NotNull
+        private Integer mainLanguageId;
+
+        @NotNull
+        private Integer exchangeLanguageId;
+
+
+
+
     }
+
 
     @Getter
     @Setter
@@ -58,11 +65,11 @@ public class MeetingDto {
         private String meetingTitle;
         private LocalDateTime meetingTime;
         private String meetingPlaceName;
-        private Double meetingPlaceLatitude;
-        private Double meetingPlaceLongitude;
         private Integer currentParticipants;
-        private Integer minParticipants;
         private Integer maxParticipants;
+        private Integer categoryId;
+        private Integer mainLanguageId;
+        private Integer exchangeLanguageId;
         private Integer status;
         private List<Long> participantIds;
         private Long hostId;
@@ -73,11 +80,11 @@ public class MeetingDto {
                     .meetingTitle(meeting.getMeetingTitle())
                     .meetingTime(meeting.getMeetingTime())
                     .meetingPlaceName(meeting.getMeetingPlaceName())
-                    .meetingPlaceLatitude(meeting.getMeetingPlaceLatitude())
-                    .meetingPlaceLongitude(meeting.getMeetingPlaceLongitude())
                     .currentParticipants(meeting.getCurrentParticipants())
-                    .minParticipants(meeting.getMinParticipants())
                     .maxParticipants(meeting.getMaxParticipants())
+                    .categoryId(meeting.getCategoryId())
+                    .mainLanguageId(meeting.getMeetingMainLanguageId())
+                    .exchangeLanguageId(meeting.getMeetingExchangeLanguageId())
                     .status(meeting.getStatus())
                     .hostId(meeting.getHost().getUserId())
                     .participantIds(meeting.getParticipants().stream()

--- a/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
@@ -36,6 +36,8 @@ public class Meeting extends BaseEntity {
     @OneToMany(mappedBy = "meeting")
     private List<Participant> participants = new ArrayList<>();
 
+    public static final long UPDATE_LIMIT_HOUR = 3; // 모임 수정이 불가능한 남은 모임시간
+
     @Column(name = "meeting_time", nullable = false)
     @Convert(converter = LocalDateTimeStringConverter.class)
     private LocalDateTime meetingTime;
@@ -100,27 +102,23 @@ public class Meeting extends BaseEntity {
         return Collections.unmodifiableList(participants);
     }
 
-    public void changeTitle(String newTitle) {
+
+    // 수정 api에서 meeting쪽 속성 일괄 변경하는 메서드
+    public void updateMeeting(String newTitle, String newPlaceName, LocalDateTime newMeetingTime, Integer newMainLanguageId, Integer newExchangeLanguageId, Integer newMaxParticipants) {
         this.meetingTitle = newTitle;
+        this.meetingPlaceName = newPlaceName;
+        this.meetingTime = newMeetingTime;
+        this.meetingMainLanguageId = newMainLanguageId;
+        this.meetingExchangeLanguageId = newExchangeLanguageId;
+        this.maxParticipants = newMaxParticipants;
     }
 
-    public void changeLocation(String placeName) { this.meetingPlaceName = placeName; }
+    public void changeStatus(int newStatus) {this.status = newStatus;}
 
-    public void changeMinimumCapacity(int newMinPpl) {
-        this.minParticipants = newMinPpl;
+    public void changeImageUrl(String newImageUrl) {
+        this.meetingImageUrl = newImageUrl;
     }
 
-    public void changeMaximumCapacity(int newMaxPpl) {
-        this.maxParticipants = newMaxPpl;
-    }
-
-    public void rescheduleMeeting(LocalDateTime newTime) {
-        this.meetingTime = newTime;
-    }
-
-    public void changeStatus(int newStatus) {
-        this.status = newStatus;
-    }
 
     /**
      * 미팅을 활성화 상태로 변경합니다.

--- a/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
+++ b/src/main/java/org/glue/glue_be/meeting/entity/Meeting.java
@@ -52,22 +52,19 @@ public class Meeting extends BaseEntity {
     @Column(name = "status", nullable = false)
     private Integer status;
 
-    @Column(name = "meeting_place_latitude", nullable = true)
-    private Double meetingPlaceLatitude;
-
-    @Column(name = "meeting_place_longitude", nullable = true)
-    private Double meetingPlaceLongitude;
-
-    @Column(name = "meeting_place_name", nullable = true)
+    @Column(name = "meeting_place_name")
     private String meetingPlaceName;
 
     @Column(name = "category_id", nullable = false)
     private Integer categoryId;
 
-    @Column(name = "language_id", nullable = false)
-    private Integer languageId;
+    @Column(name = "meeting_main_language_id", nullable = false)
+    private Integer meetingMainLanguageId;
 
-    @Column(name = "meeting_image_url", nullable = true)
+    @Column(name = "meeting_exchange_language_id", nullable = false)
+    private Integer meetingExchangeLanguageId;
+
+    @Column(name = "meeting_image_url")
     private String meetingImageUrl;
 
     @Builder
@@ -78,11 +75,12 @@ public class Meeting extends BaseEntity {
                     Integer minParticipants,
                     Integer maxParticipants,
                     Integer status,
-                    Double meetingPlaceLatitude,
-                    Double meetingPlaceLongitude,
                     String meetingPlaceName,
                     Integer categoryId,
-                    Integer languageId) {
+                    Integer meetingMainLanguageId,
+                    Integer meetingExchangeLanguageId,
+                    String meetingImageUrl
+        ) {
         this.host = host;
         this.meetingTitle = meetingTitle;
         this.meetingTime = meetingTime;
@@ -90,12 +88,12 @@ public class Meeting extends BaseEntity {
         this.minParticipants = minParticipants;
         this.maxParticipants = maxParticipants;
         this.status = status;
-        this.meetingPlaceLatitude = meetingPlaceLatitude;
-        this.meetingPlaceLongitude = meetingPlaceLongitude;
         this.meetingPlaceName = meetingPlaceName;
         this.participants = new ArrayList<>();
         this.categoryId = categoryId;
-        this.languageId = languageId;
+        this.meetingMainLanguageId = meetingMainLanguageId;
+        this.meetingExchangeLanguageId = meetingExchangeLanguageId;
+        this.meetingImageUrl = meetingImageUrl;
     }
 
     public List<Participant> getParticipants() {
@@ -106,12 +104,7 @@ public class Meeting extends BaseEntity {
         this.meetingTitle = newTitle;
     }
 
-    public void changeLocation(Double latitude, Double longitude, String placeName) {
-        this.meetingPlaceLatitude = latitude;
-        this.meetingPlaceLongitude = longitude;
-        this.meetingPlaceName = placeName;
-    }
-
+    public void changeLocation(String placeName) { this.meetingPlaceName = placeName; }
 
     public void changeMinimumCapacity(int newMinPpl) {
         this.minParticipants = newMinPpl;

--- a/src/main/java/org/glue/glue_be/meeting/repository/ParticipantRepository.java
+++ b/src/main/java/org/glue/glue_be/meeting/repository/ParticipantRepository.java
@@ -15,4 +15,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     List<Participant> findByUser_UserId(Long userId);
     Optional<Participant> findByUserAndMeeting(User user, Meeting meeting);
     boolean existsByUserAndMeeting(User user, Meeting meeting);
+	void deleteByMeeting_MeetingId(Long meetingMeetingId);
+
 }

--- a/src/main/java/org/glue/glue_be/meeting/service/MeetingService.java
+++ b/src/main/java/org/glue/glue_be/meeting/service/MeetingService.java
@@ -32,39 +32,33 @@ public class MeetingService {
      * 모임 생성
      */
     @Transactional
-    public MeetingDto.CreateResponse createMeeting(MeetingDto.CreateRequest request, Long creatorId) {
-        // 유효성 검증
-        if (request.getMinPpl() > request.getMaxPpl()) {
-            throw new BaseException(MeetingResponseStatus.MIN_OVER_MAX);
-        }
+    public MeetingDto.CreateResponse createMeeting(MeetingDto.CreateRequest meetingRequest, Long creatorId) {
 
         // 사용자 조회
         User creator = userRepository.findById(creatorId)
                 .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
 
-        // 모임 생성
-        Meeting meeting = Meeting.builder()
-                .meetingTitle(request.getMeetingTitle())
-                .meetingTime(request.getMeetingTime())
-                .meetingPlaceName(request.getMeetingPlaceName())
-                .meetingPlaceLatitude(request.getMeetingPlaceLatitude())
-                .meetingPlaceLongitude(request.getMeetingPlaceLongitude())
-                .minParticipants(request.getMinPpl())
-                .maxParticipants(request.getMaxPpl())
-                .currentParticipants(1) // 생성자가 첫 번째 참가자
-                .status(1) // 1: 활성화 상태
-                .host(creator) // 호스트 설정
-                .build();
-
+        // 2. 모임 생성
+        Meeting meeting = Meeting.builder() // todo: toEntity 팩토리 메서드로 대체
+            .meetingTitle(meetingRequest.getMeetingTitle())
+            .meetingTime(meetingRequest.getMeetingTime())
+            .meetingPlaceName(meetingRequest.getMeetingPlaceName())
+            .minParticipants(0) // 1.0에선 최소인원이 안쓰이기에 일단 0으로 고정
+            .maxParticipants(meetingRequest.getMaxParticipants())
+            .currentParticipants(1)
+            .status(1)
+            .categoryId(meetingRequest.getCategoryId())
+            .meetingMainLanguageId(meetingRequest.getMainLanguageId())
+            .meetingExchangeLanguageId(meetingRequest.getExchangeLanguageId())
+            .host(creator)
+            .build();
         Meeting savedMeeting = meetingRepository.save(meeting);
 
-        // 생성자를 참가자로 추가
-        Participant participant = Participant.builder()
-                .user(creator)
-                .meeting(savedMeeting)
-                .build();
-
+        // 3. 게시자를 참가자 테이블에 추가
+        Participant participant = Participant.builder().user(creator).meeting(savedMeeting).build();
         participantRepository.save(participant);
+
+        // 3.5. onetomany로 관리하는 participants 리스트에 추가
         savedMeeting.addParticipant(participant);
 
         return MeetingDto.CreateResponse.builder()

--- a/src/main/java/org/glue/glue_be/meeting/service/MeetingService.java
+++ b/src/main/java/org/glue/glue_be/meeting/service/MeetingService.java
@@ -39,7 +39,7 @@ public class MeetingService {
                 .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
 
         // 2. 모임 생성
-        Meeting meeting = Meeting.builder() // todo: toEntity 팩토리 메서드로 대체
+        Meeting meeting = Meeting.builder()
             .meetingTitle(meetingRequest.getMeetingTitle())
             .meetingTime(meetingRequest.getMeetingTime())
             .meetingPlaceName(meetingRequest.getMeetingPlaceName())

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
 import org.glue.glue_be.common.response.BaseResponse;
 import org.glue.glue_be.post.dto.request.CreatePostRequest;
+import org.glue.glue_be.post.dto.request.UpdatePostRequest;
 import org.glue.glue_be.post.dto.response.BumpPostResponse;
 import org.glue.glue_be.post.dto.response.CreatePostResponse;
 import org.glue.glue_be.post.dto.response.GetPostResponse;
@@ -37,6 +38,12 @@ public class PostController {
 	}
 
 	// 3. 게시글 수정 (로그인 필수)
+	@PostMapping("/{postId}")
+	public BaseResponse<Void> updatePost(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth,
+		@RequestBody @Valid UpdatePostRequest req) {
+		postService.updatePost(postId, auth.getUserId(), req);
+		return new BaseResponse<>();
+	}
 
 	// 4. 게시글 삭제 (로그인 필수)
 	@DeleteMapping("/{postId}")

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -53,9 +53,10 @@ public class PostController {
 	@GetMapping
 	public BaseResponse<GetPostsResponse> getPosts(@RequestParam(required = false) Long lastPostId,
 		@RequestParam(defaultValue = "10") int size,
-		@RequestParam(required = false) Integer categoryId
+		@RequestParam(required = false) Integer categoryId,
+		@AuthenticationPrincipal CustomUserDetails auth
 	) {
-		GetPostsResponse response = postService.getPosts(lastPostId, size, categoryId);
+		GetPostsResponse response = postService.getPosts(lastPostId, size, categoryId, auth.getUserId());
 		return new BaseResponse<>(response);
 	}
 

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -96,8 +96,8 @@ public class PostController {
 	// 9. 홈화면 인기 게시글
 	@GetMapping("/popular")
 	public BaseResponse<?> getPopularPosts(@AuthenticationPrincipal CustomUserDetails auth,
-		@RequestParam(defaultValue = "3") int size) {
-		if(size <= 3){
+		@RequestParam(defaultValue = "2") int size) {
+		if(size <= 2){
 			List<MainPagePostResponse> list = postService.getMainPagePosts(size, auth.getUserId());
 			return new BaseResponse<>(list);
 		} else {
@@ -110,11 +110,11 @@ public class PostController {
 	 // 9. 언어 매칭 게시글 조회
 	@GetMapping("/language-match")
 	public BaseResponse<?> getLanguageMatch(
-		@RequestParam(defaultValue = "3") int size,
+		@RequestParam(defaultValue = "2") int size,
 		@AuthenticationPrincipal CustomUserDetails auth
 	) {
 		Long userId = auth.getUserId();
-		if (size <= 3) {
+		if (size <= 2) {
 			List<MainPagePostResponse> list = postService.getLanguageMatchedMain(size, userId);
 			return new BaseResponse<>(list);
 		} else {

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -7,13 +7,12 @@ import org.glue.glue_be.auth.jwt.CustomUserDetails;
 import org.glue.glue_be.common.response.BaseResponse;
 import org.glue.glue_be.post.dto.request.CreatePostRequest;
 import org.glue.glue_be.post.dto.request.UpdatePostRequest;
-import org.glue.glue_be.post.dto.response.BumpPostResponse;
-import org.glue.glue_be.post.dto.response.CreatePostResponse;
-import org.glue.glue_be.post.dto.response.GetPostResponse;
-import org.glue.glue_be.post.dto.response.GetPostsResponse;
+import org.glue.glue_be.post.dto.response.*;
 import org.glue.glue_be.post.service.PostService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RestController
@@ -24,7 +23,7 @@ public class PostController {
 	private final PostService postService;
 
 
-	// 1. 게시글 작성 (로그인 필수)
+	// 1. 게시글 작성
 	@PostMapping
 	public BaseResponse<CreatePostResponse> createPost(@RequestBody @Valid CreatePostRequest req, @AuthenticationPrincipal CustomUserDetails auth) {
 		return new BaseResponse<>(postService.createPost(req, auth.getUserId()));
@@ -37,7 +36,7 @@ public class PostController {
 		return new BaseResponse<>(postService.getPost(postId, auth.getUserId()));
 	}
 
-	// 3. 게시글 수정 (로그인 필수)
+	// 3. 게시글 수정
 	@PostMapping("/{postId}")
 	public BaseResponse<Void> updatePost(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth,
 		@RequestBody @Valid UpdatePostRequest req) {
@@ -45,7 +44,7 @@ public class PostController {
 		return new BaseResponse<>();
 	}
 
-	// 4. 게시글 삭제 (로그인 필수)
+	// 4. 게시글 삭제
 	@DeleteMapping("/{postId}")
 	public BaseResponse<Void> deletePost(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth) {
 		postService.deletePost(postId, auth.getUserId());
@@ -53,7 +52,7 @@ public class PostController {
 	}
 
 
-	// 5. 게시글 끌올 (로그인 필수)
+	// 5. 게시글 끌올
 	@GetMapping("/{postId}/bump")
 	public BaseResponse<BumpPostResponse> bumpPost(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth) {
 		return new BaseResponse<>(postService.bumpPost(postId, auth.getUserId()));
@@ -83,11 +82,25 @@ public class PostController {
 	}
 
 
-	// 8. 좋아요 등록(토글) (로그인 필수)
+	// 8. 좋아요 등록(토글)
 	@GetMapping("/{postId}/like")
 	public BaseResponse<Void> toggleLike(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth) {
 		postService.toggleLike(postId, auth.getUserId());
 		return new BaseResponse<>();
 	}
+
+	// 9. 홈화면 인기 게시글
+	@GetMapping("/popular")
+	public BaseResponse<?> getPopularPosts(@AuthenticationPrincipal CustomUserDetails auth,
+		@RequestParam(defaultValue = "3") int size) {
+		if(size <= 3){
+			List<MainPagePostResponse> list = postService.getMainPagePosts(size, auth.getUserId());
+			return new BaseResponse<>(list);
+		} else {
+			GetPostsResponse response = postService.getPopularDetailed(size, auth.getUserId());
+			return new BaseResponse<>(response);
+		}
+	}
+
 
 }

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -103,4 +103,21 @@ public class PostController {
 	}
 
 
+	 // 9. 언어 매칭 게시글 조회
+	@GetMapping("/language-match")
+	public BaseResponse<?> getLanguageMatch(
+		@RequestParam(defaultValue = "3") int size,
+		@AuthenticationPrincipal CustomUserDetails auth
+	) {
+		Long userId = auth.getUserId();
+		if (size <= 3) {
+			List<MainPagePostResponse> list = postService.getLanguageMatchedMain(size, userId);
+			return new BaseResponse<>(list);
+		} else {
+			GetPostsResponse resp = postService.getLanguageMatchedDetailed(size, userId);
+			return new BaseResponse<>(resp);
+		}
+	}
+
+
 }

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.CustomUserDetails;
 import org.glue.glue_be.common.response.BaseResponse;
 import org.glue.glue_be.post.dto.request.CreatePostRequest;
+import org.glue.glue_be.post.dto.response.BumpPostResponse;
 import org.glue.glue_be.post.dto.response.CreatePostResponse;
 import org.glue.glue_be.post.dto.response.GetPostResponse;
 import org.glue.glue_be.post.dto.response.GetPostsResponse;
@@ -42,9 +43,8 @@ public class PostController {
 
 	// 5. 게시글 끌올 (로그인 필수)
 	@GetMapping("/{postId}/bump")
-	public BaseResponse<Void> bumpPost(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth) {
-		postService.bumpPost(postId, auth.getUserId());
-		return new BaseResponse<>();
+	public BaseResponse<BumpPostResponse> bumpPost(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth) {
+		return new BaseResponse<BumpPostResponse>(postService.bumpPost(postId, auth.getUserId()));
 	}
 
 	// 6. 게시글 목록 조회 (무한 스크롤 / cursor 기반)

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -62,12 +62,16 @@ public class PostController {
 	// - bumpedAt 가 있는 글이 먼저 우선적으로 내림차순으로 최근 끌올순 구현
 	// - bumpedAt 가 없는 글들 중에선 createdAt 순
 	@GetMapping
-	public BaseResponse<GetPostsResponse> getPosts(@RequestParam(required = false) Long lastPostId,
+	public BaseResponse<GetPostsResponse> getPosts(
+		@RequestParam(required = false) Long lastPostId,
 		@RequestParam(defaultValue = "10") int size,
 		@RequestParam(required = false) Integer categoryId,
+		@RequestParam(defaultValue = "false") boolean languageToggle,   // 맞춤언어
 		@AuthenticationPrincipal CustomUserDetails auth
 	) {
-		GetPostsResponse response = postService.getPosts(lastPostId, size, categoryId, auth.getUserId());
+		GetPostsResponse response = postService.getPosts(
+			lastPostId, size, categoryId, languageToggle, auth.getUserId()
+		);
 		return new BaseResponse<>(response);
 	}
 

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -32,8 +32,8 @@ public class PostController {
 
 	// 2. 게시글 단건 조회
 	@GetMapping("/{postId}")
-	public BaseResponse<GetPostResponse> getPost(@PathVariable Long postId) {
-		return new BaseResponse<>(postService.getPost(postId));
+	public BaseResponse<GetPostResponse> getPost(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth) {
+		return new BaseResponse<>(postService.getPost(postId, auth.getUserId()));
 	}
 
 	// 3. 게시글 수정 (로그인 필수)

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -66,6 +66,14 @@ public class PostController {
 	}
 
 	// 7. 검색 결과 게시글 목록 조회
+	@GetMapping("/search")
+	public BaseResponse<GetPostsResponse> searchPosts(
+		@RequestParam String keyword, @RequestParam(required = false) Long lastPostId,
+		@RequestParam(defaultValue = "10") int size,
+		@AuthenticationPrincipal CustomUserDetails auth
+	) {
+		return new BaseResponse<>(postService.searchPosts(lastPostId, size, keyword, auth.getUserId()));
+	}
 
 
 	// 8. 좋아요 등록(토글) (로그인 필수)

--- a/src/main/java/org/glue/glue_be/post/controller/PostController.java
+++ b/src/main/java/org/glue/glue_be/post/controller/PostController.java
@@ -39,12 +39,17 @@ public class PostController {
 	// 3. 게시글 수정 (로그인 필수)
 
 	// 4. 게시글 삭제 (로그인 필수)
+	@DeleteMapping("/{postId}")
+	public BaseResponse<Void> deletePost(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth) {
+		postService.deletePost(postId, auth.getUserId());
+		return new BaseResponse<>();
+	}
 
 
 	// 5. 게시글 끌올 (로그인 필수)
 	@GetMapping("/{postId}/bump")
 	public BaseResponse<BumpPostResponse> bumpPost(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails auth) {
-		return new BaseResponse<BumpPostResponse>(postService.bumpPost(postId, auth.getUserId()));
+		return new BaseResponse<>(postService.bumpPost(postId, auth.getUserId()));
 	}
 
 	// 6. 게시글 목록 조회 (무한 스크롤 / cursor 기반)

--- a/src/main/java/org/glue/glue_be/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/glue/glue_be/post/dto/request/CreatePostRequest.java
@@ -25,6 +25,7 @@ public class CreatePostRequest {
 		@NotNull(message = "카테고리 id는 필수값입니다")
 		private Integer categoryId;
 
+		@NotBlank(message = "모임 장소는 필수값입니다")
 		private String meetingPlaceName;
 
 		@NotNull(message = "모임일시는 필수값입니다")
@@ -32,12 +33,11 @@ public class CreatePostRequest {
 		@Future(message = "모임 시간은 현재 시간 이후여야 합니다")
 		private LocalDateTime meetingTime;
 
-		private Double meetingPlaceLatitude;
+		@NotNull(message = "모임 메인언어 id는 필수값입니다")
+		private Integer mainLanguageId;
 
-		private Double meetingPlaceLongitude;
-
-		@NotNull(message = "언어 id는 필수값입니다")
-		private Integer languageId;
+		@NotNull(message = "모임 교환언어 id는 필수값입니다")
+		private Integer exchangeLanguageId;
 
 		@NotNull(message = "최대 참가자수는 필수값입니다")
 		private Integer maxParticipants;

--- a/src/main/java/org/glue/glue_be/post/dto/request/UpdatePostRequest.java
+++ b/src/main/java/org/glue/glue_be/post/dto/request/UpdatePostRequest.java
@@ -1,0 +1,62 @@
+package org.glue.glue_be.post.dto.request;
+
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Getter
+public class UpdatePostRequest {
+
+	@NotNull
+	@Valid
+	private MeetingDto meeting;
+
+	@NotNull
+	@Valid
+	private PostDto post;
+
+	@Getter
+	public static class MeetingDto {
+
+		@NotBlank(message = "모임 제목은 필수값입니다.")
+		private String meetingTitle;
+
+		@NotBlank(message = "모임 장소는 필수값입니다")
+		private String meetingPlaceName;
+
+		@NotNull(message = "모임일시는 필수값입니다")
+		@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+		@Future(message = "모임 시간은 현재 시간 이후여야 합니다")
+		private LocalDateTime meetingTime;
+
+		@NotNull(message = "모임 메인언어 id는 필수값입니다")
+		private Integer mainLanguageId;
+
+		@NotNull(message = "모임 교환언어 id는 필수값입니다")
+		private Integer exchangeLanguageId;
+
+		@Min(value = 1, message = "최대 참가자수는 최소 1명 이상이어야 합니다")
+		@Max(value = 10, message = "최대 참가자수는 10명을 초과할 수 없습니다")
+		private Integer maxParticipants;
+	}
+
+	@Getter
+	public static class PostDto {
+
+		@NotBlank(message = "게시글 제목은 필수값입니다.")
+		private String title;
+
+		@NotBlank(message = "게시글 내용은 필수값입니다.")
+		private String content;
+
+		private List<String> imageUrls;
+
+	}
+}

--- a/src/main/java/org/glue/glue_be/post/dto/response/BumpPostResponse.java
+++ b/src/main/java/org/glue/glue_be/post/dto/response/BumpPostResponse.java
@@ -1,0 +1,7 @@
+package org.glue.glue_be.post.dto.response;
+
+
+public record BumpPostResponse(
+	int bumpCount,
+	int maxBumpCount
+) {}

--- a/src/main/java/org/glue/glue_be/post/dto/response/GetPostResponse.java
+++ b/src/main/java/org/glue/glue_be/post/dto/response/GetPostResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import org.glue.glue_be.common.dto.UserSummary;
+import org.glue.glue_be.post.entity.Post;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,7 +36,11 @@ public class GetPostResponse {
 
 		private Integer maxParticipants;
 
-		private Integer languageId;
+		private String meetingPlaceName;
+
+		private Integer mainLanguageId;
+
+		private Integer exchangeLanguageId;
 
 		private Integer meetingStatus;
 
@@ -75,6 +80,10 @@ public class GetPostResponse {
 
 		@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
 		private LocalDateTime bumpedAt;
+
+		// 끌올 직전 유저에게 몇번 했는지 알려주기 위해 끌올 카운트 포함
+		private Integer bumpedCount;
+		private Integer bumpLimit;
 
 		private Integer likeCount;
 

--- a/src/main/java/org/glue/glue_be/post/dto/response/GetPostResponse.java
+++ b/src/main/java/org/glue/glue_be/post/dto/response/GetPostResponse.java
@@ -35,6 +35,8 @@ public class GetPostResponse {
 
 		private Integer maxParticipants;
 
+		private String meetingTitle;
+
 		private String meetingPlaceName;
 
 		private Integer mainLanguageId;

--- a/src/main/java/org/glue/glue_be/post/dto/response/GetPostResponse.java
+++ b/src/main/java/org/glue/glue_be/post/dto/response/GetPostResponse.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import org.glue.glue_be.common.dto.UserSummary;
-import org.glue.glue_be.post.entity.Post;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -86,6 +85,7 @@ public class GetPostResponse {
 		private Integer bumpLimit;
 
 		private Integer likeCount;
+		private Boolean isLiked;
 
 		private List<PostImageDto> postImageUrl;
 

--- a/src/main/java/org/glue/glue_be/post/dto/response/GetPostsResponse.java
+++ b/src/main/java/org/glue/glue_be/post/dto/response/GetPostsResponse.java
@@ -21,6 +21,10 @@ public class GetPostsResponse {
 	@Builder
 	public static class PostItem {
 
+		// 좋아요 상태 상수
+		public static final int LIKED = 1;
+		public static final int NOT_LIKED = 0;
+
 		private Long postId;
 
 		private Integer viewCount;
@@ -41,10 +45,13 @@ public class GetPostsResponse {
 
 		private String thumbnailUrl;
 
+		// 현재 로그인한 유저가 이 게시글에 좋아요를 눌렀는지 1(예), 0(아니오)
+		private Integer isUserLikedThisPost;
+
 	}
 
 	// 엔티티 → 목록 itemDTO 변환용 메서드
-	public static PostItem ofEntity(Post p) {
+	public static PostItem ofEntity(Post p, boolean isLiked) {
 		return PostItem.builder()
 			.postId(p.getId())
 			.viewCount(p.getViewCount())
@@ -58,6 +65,7 @@ public class GetPostsResponse {
 			.thumbnailUrl(p.getImages().isEmpty()
 				? null
 				: p.getImages().get(0).getImageUrl())
+			.isUserLikedThisPost(isLiked ? PostItem.LIKED : PostItem.NOT_LIKED)
 			.build();
 	}
 

--- a/src/main/java/org/glue/glue_be/post/dto/response/MainPagePostResponse.java
+++ b/src/main/java/org/glue/glue_be/post/dto/response/MainPagePostResponse.java
@@ -1,0 +1,24 @@
+package org.glue.glue_be.post.dto.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@Builder
+public class MainPagePostResponse {
+	Integer postId;
+	Integer categoryId;
+	LocalDateTime createdAt;
+	String title;
+	String content;
+	Integer likeCount;
+	Integer isLiked;
+	Integer currentParticipants;
+	Integer maxParticipants;
+
+		
+}

--- a/src/main/java/org/glue/glue_be/post/entity/Post.java
+++ b/src/main/java/org/glue/glue_be/post/entity/Post.java
@@ -51,7 +51,7 @@ public class Post {
     private List<Like> likes = new ArrayList<>();
 
     @Builder
-    private Post(Meeting meeting, String title, String content, LocalDateTime bumpedAt) {
+    private Post(Meeting meeting, String title, String content) {
         this.meeting = meeting;
         this.title = title;
         this.content = content;

--- a/src/main/java/org/glue/glue_be/post/entity/Post.java
+++ b/src/main/java/org/glue/glue_be/post/entity/Post.java
@@ -39,6 +39,11 @@ public class Post {
     @Convert(converter = LocalDateTimeStringConverter.class)
     private LocalDateTime bumpedAt;
 
+    public static final int BUMP_LIMIT = 3;
+
+    @Column(name = "bump_count", nullable = false)
+    private Integer bumpCount;
+
     @OneToMany(mappedBy = "post")
     private List<PostImage> images = new ArrayList<>();
 
@@ -52,6 +57,7 @@ public class Post {
         this.content = content;
         this.viewCount = 0;
         this.bumpedAt = null;
+        this.bumpCount = 0;
     }
 
     public void updatePost(String title, String content) {
@@ -60,13 +66,11 @@ public class Post {
     }
 
     public void bump(LocalDateTime now) {
-
-        final int BUMP_COOLTIME_DAYS = 3;
-
-        if (bumpedAt != null && bumpedAt.plusDays(BUMP_COOLTIME_DAYS).isAfter(now)) {
-            throw new BaseException(PostResponseStatus.POST_CANNOT_BUMP_YET);
+        if (bumpedAt != null && this.bumpCount >= BUMP_LIMIT) {
+            throw new BaseException(PostResponseStatus.POST_CANNOT_BUMP_MORE);
         }
         this.bumpedAt = now;
+        this.bumpCount++;
     }
 
     public void increaseViewCount() {

--- a/src/main/java/org/glue/glue_be/post/repository/LikeRepository.java
+++ b/src/main/java/org/glue/glue_be/post/repository/LikeRepository.java
@@ -5,6 +5,8 @@ import org.glue.glue_be.post.entity.Like;
 import org.glue.glue_be.post.entity.Post;
 import org.glue.glue_be.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,4 +19,12 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 	Optional<Like> findByUserAndPost(User user, Post post);
 
 	List<Like> findByUser_UserIdOrderByCreatedAtDesc(Long userId);
+
+
+	// 특정 유저가 여러 게시글에 좋아요를 눌렀는지 한 번에 조회
+	// 쿼리문 읽을 때 개인적으로 from -> where순으로 읽고 select를 마지막에 읽으면 의미 이해가 좀 쉬웠음
+	// Like 테이블에서, user_id가 입력 userId와 같고, post_id가 postIds 배열에 속해있는 것을 찾아, post_id 외래키 속성만 select
+	@Query("SELECT l.post.id FROM Like l WHERE l.user.userId = :userId AND l.post.id IN :postIds")
+	List<Long> findLikedPostIdsByUserAndPostIds(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
+
 }

--- a/src/main/java/org/glue/glue_be/post/repository/LikeRepository.java
+++ b/src/main/java/org/glue/glue_be/post/repository/LikeRepository.java
@@ -29,4 +29,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
 	Boolean existsByUser_UserIdAndPost_Id(Long userId, Long postId);
 
+	void deleteByPost_Id(Long postId);
+
 }

--- a/src/main/java/org/glue/glue_be/post/repository/LikeRepository.java
+++ b/src/main/java/org/glue/glue_be/post/repository/LikeRepository.java
@@ -27,4 +27,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 	@Query("SELECT l.post.id FROM Like l WHERE l.user.userId = :userId AND l.post.id IN :postIds")
 	List<Long> findLikedPostIdsByUserAndPostIds(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
 
+	Boolean existsByUser_UserIdAndPost_Id(Long userId, Long postId);
+
 }

--- a/src/main/java/org/glue/glue_be/post/repository/PostImageRepository.java
+++ b/src/main/java/org/glue/glue_be/post/repository/PostImageRepository.java
@@ -14,4 +14,7 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 	List<PostImage> findAllByPost_Id(Long postId);
 
 	void deleteByPost_Id(Long postId);
+
+	void deleteByPost_IdAndImageUrl(Long postId, String url);
+
 }

--- a/src/main/java/org/glue/glue_be/post/repository/PostImageRepository.java
+++ b/src/main/java/org/glue/glue_be/post/repository/PostImageRepository.java
@@ -5,8 +5,13 @@ import org.glue.glue_be.post.entity.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 
 @Repository
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
+	List<PostImage> findAllByPost_Id(Long postId);
+
+	void deleteByPost_Id(Long postId);
 }

--- a/src/main/java/org/glue/glue_be/post/repository/PostRepository.java
+++ b/src/main/java/org/glue/glue_be/post/repository/PostRepository.java
@@ -3,6 +3,7 @@ package org.glue.glue_be.post.repository;
 
 import java.util.Optional;
 import org.glue.glue_be.post.entity.Post;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -133,4 +134,18 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		@Param("limit")        int limit
 	);
 
+
+
+	// 미팅시간 안넘긴 게시글 중 좋아요 상위 순 가져오기
+	@Query("""
+        SELECT p
+        FROM Post p
+        WHERE p.meeting.meetingTime > :now
+        ORDER BY SIZE(p.likes) DESC
+        """)
+	List<Post> findPopularPosts(
+		@Param("now") LocalDateTime now,
+		Pageable pageable
+	);
 }
+

--- a/src/main/java/org/glue/glue_be/post/repository/PostRepository.java
+++ b/src/main/java/org/glue/glue_be/post/repository/PostRepository.java
@@ -137,6 +137,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 
 	// 미팅시간 안넘긴 게시글 중 좋아요 상위 순 가져오기
+	// Pageable 인자로 받지만 고정 사이즈의 게시글만 받아오므로 List<Post>로 리턴타입 지정
 	@Query("""
         SELECT p
         FROM Post p
@@ -144,6 +145,26 @@ public interface PostRepository extends JpaRepository<Post, Long> {
         ORDER BY SIZE(p.likes) DESC
         """)
 	List<Post> findPopularPosts(
+		@Param("now") LocalDateTime now,
+		Pageable pageable
+	);
+
+
+	// 미팅시간 안넘긴 게시글 중 입력으로 들어온 주언어, 학습언어와 일치하는 게시글 가져오기
+	// Pageable 인자로 받지만 고정 사이즈의 게시글만 받아오므로 List<Post>로 리턴타입 지정
+	@Query("""
+        SELECT p
+        FROM Post p
+        WHERE p.meeting.meetingMainLanguageId = :mainLang
+          AND p.meeting.meetingExchangeLanguageId = :exchangeLang
+          AND p.meeting.meetingTime > :now
+        ORDER BY
+          COALESCE(p.bumpedAt, p.meeting.createdAt) DESC,
+          p.id DESC
+        """)
+	List<Post> findByLanguageMatch(
+		@Param("mainLang") Integer mainLang,
+		@Param("exchangeLang") Integer exchangeLang,
 		@Param("now") LocalDateTime now,
 		Pageable pageable
 	);

--- a/src/main/java/org/glue/glue_be/post/response/PostImageResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/post/response/PostImageResponseStatus.java
@@ -1,0 +1,23 @@
+package org.glue.glue_be.post.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.glue.glue_be.common.response.ResponseStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+
+@Getter
+@AllArgsConstructor
+public enum PostImageResponseStatus implements ResponseStatus {
+
+	POST_IMAGE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "postImage 레코드를 찾을 수 없습니다"),
+
+	;
+
+	private final HttpStatusCode httpStatusCode;
+	private final boolean isSuccess;
+	private final int code;
+	private final String message;
+}

--- a/src/main/java/org/glue/glue_be/post/response/PostResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/post/response/PostResponseStatus.java
@@ -13,7 +13,10 @@ public enum PostResponseStatus implements ResponseStatus {
 
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 게시글입니다"),
 	POST_CANNOT_BUMP_MORE(HttpStatus.TOO_MANY_REQUESTS, false, 400 , "가능한 끌올 횟수를 모두 소진했습니다." ),
-	POST_NOT_AUTHOR(HttpStatus.FORBIDDEN, false, 403, "게시글 작성자만 접근할 수 있습니다.");
+	POST_NOT_AUTHOR(HttpStatus.FORBIDDEN, false, 403, "게시글 작성자만 접근할 수 있습니다."),
+	POST_CANNOT_UPDATE_CLOSE_TO_MEETING(HttpStatus.BAD_REQUEST, false, 400 , "잘못된 모임수정입니다. 시각을 확인하세요." ),
+
+	;
 
 	private final HttpStatusCode httpStatusCode;
 	private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/post/response/PostResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/post/response/PostResponseStatus.java
@@ -12,7 +12,7 @@ import org.springframework.http.HttpStatusCode;
 public enum PostResponseStatus implements ResponseStatus {
 
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 게시글입니다"),
-	POST_CANNOT_BUMP_YET(HttpStatus.NOT_EXTENDED, false, 400 , "이전 끌올에서 3일이 지나야 끌올할 수 있습니다." ),
+	POST_CANNOT_BUMP_MORE(HttpStatus.TOO_MANY_REQUESTS, false, 400 , "가능한 끌올 횟수를 모두 소진했습니다." ),
 	POST_NOT_AUTHOR(HttpStatus.FORBIDDEN, false, 403, "게시글 작성자만 접근할 수 있습니다.");
 
 	private final HttpStatusCode httpStatusCode;

--- a/src/main/java/org/glue/glue_be/post/service/PostService.java
+++ b/src/main/java/org/glue/glue_be/post/service/PostService.java
@@ -66,10 +66,9 @@ public class PostService {
 			.maxParticipants(meetingRequest.getMaxParticipants())
 			.currentParticipants(1)
 			.status(1)
-			.meetingPlaceLatitude(meetingRequest.getMeetingPlaceLatitude())
-			.meetingPlaceLongitude(meetingRequest.getMeetingPlaceLongitude())
 			.categoryId(meetingRequest.getCategoryId())
-			.languageId(meetingRequest.getLanguageId())
+			.meetingMainLanguageId(meetingRequest.getMainLanguageId())
+			.meetingExchangeLanguageId(meetingRequest.getExchangeLanguageId())
 			.host(creator)
 			.build();
 		Meeting savedMeeting = meetingRepository.save(meeting);
@@ -79,7 +78,6 @@ public class PostService {
 		participantRepository.save(participant);
 
 		// 3.5. onetomany로 관리하는 participants 리스트에 추가
-		// todo: 직접적인 연관관계 매핑이 너무 많아 생각보다 어려운듯 나중에 논의하기
 		savedMeeting.addParticipant(participant);
 
 		// 4. 게시글 생성
@@ -155,8 +153,10 @@ public class PostService {
 			.creator(creator)
 			.meetingTime(meeting.getMeetingTime())
 			.currentParticipants(meeting.getCurrentParticipants())
+			.meetingPlaceName(meeting.getMeetingPlaceName())
 			.maxParticipants(meeting.getMaxParticipants())
-			.languageId(meeting.getLanguageId())
+			.mainLanguageId(meeting.getMeetingMainLanguageId())
+			.exchangeLanguageId(meeting.getMeetingExchangeLanguageId())
 			.meetingStatus(meeting.getStatus())
 			.participants(participantDtos)
 			.createdAt(meeting.getCreatedAt())
@@ -169,6 +169,8 @@ public class PostService {
 			.content(post.getContent())
 			.viewCount(post.getViewCount())
 			.bumpedAt(post.getBumpedAt())
+			.bumpedCount(post.getBumpCount())
+			.bumpLimit(Post.BUMP_LIMIT)
 			.likeCount(post.getLikes().size())
 			.postImageUrl(imageUrls)
 			.build();
@@ -231,6 +233,8 @@ public class PostService {
 		}
 	}
 
+	// 게시글 목록 조회
+	// 무한스크롤 + 카테고리별 필터링
 	@Transactional(readOnly = true)
 	public GetPostsResponse getPosts(Long lastPostId, int size, Integer categoryId) {
 

--- a/src/main/java/org/glue/glue_be/post/service/PostService.java
+++ b/src/main/java/org/glue/glue_be/post/service/PostService.java
@@ -44,6 +44,8 @@ public class PostService {
 
 	private final ReminderSchedulerService reminderSchedulerService;
 
+
+
 	// 게시글 사진이 추가 및 삭제될 때 meeting image url도 함께 업데이트 시키는 메소드
 	public void updateMeetingImageUrl(Long meetingId) {
 		meetingRepository.updateMeetingImageUrl(meetingId);
@@ -120,7 +122,6 @@ public class PostService {
 		// 1. post, meeting, user 객체 가져오기
 		Post post = postRepository.findById(postId).orElseThrow(() -> new BaseException(PostResponseStatus.POST_NOT_FOUND));
 		Meeting meeting = post.getMeeting();
-		User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
 
 
 		// 2. 응답 dto 구성

--- a/src/main/java/org/glue/glue_be/post/service/PostService.java
+++ b/src/main/java/org/glue/glue_be/post/service/PostService.java
@@ -186,6 +186,7 @@ public class PostService {
 			.currentParticipants(meeting.getCurrentParticipants())
 			.meetingPlaceName(meeting.getMeetingPlaceName())
 			.maxParticipants(meeting.getMaxParticipants())
+			.meetingTitle(meeting.getMeetingTitle())
 			.mainLanguageId(meeting.getMeetingMainLanguageId())
 			.exchangeLanguageId(meeting.getMeetingExchangeLanguageId())
 			.meetingStatus(meeting.getStatus())

--- a/src/main/java/org/glue/glue_be/post/service/PostService.java
+++ b/src/main/java/org/glue/glue_be/post/service/PostService.java
@@ -188,7 +188,7 @@ public class PostService {
 
 
 	// 게시글 끌올
-	public void bumpPost(Long postId, Long userId) {
+	public BumpPostResponse bumpPost(Long postId, Long userId) {
 
 		Post post = postRepository.findById(postId).orElseThrow(() -> new BaseException(PostResponseStatus.POST_NOT_FOUND));
 
@@ -196,6 +196,13 @@ public class PostService {
 		if (!post.getMeeting().isHost(userId)) throw new BaseException(PostResponseStatus.POST_NOT_AUTHOR);
 
 		post.bump(LocalDateTime.now());
+
+		return new BumpPostResponse(
+			post.getBumpCount(),
+			Post.BUMP_LIMIT
+		);
+
+
 	}
 
 

--- a/src/main/java/org/glue/glue_be/user/repository/UserRepository.java
+++ b/src/main/java/org/glue/glue_be/user/repository/UserRepository.java
@@ -17,4 +17,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	// 2. 이메일로 유저찾기
 	Optional<User> findByEmail(String email);
+
+	// 3. 닉네임 가진 유저가 이미 있는지
+	boolean existsByNickname(String nickname);
+
+	// 4. 이미 존재하는 이메일인지
+	boolean existsByEmail(String email);
+
 }


### PR DESCRIPTION
PR이 고봉밥이지만 좀 빡세고 핵심이라 생각하는 부분은 구현 5,6,7, 변경 2,3,6,7이라 생각합니다. 이 부분 중점으로 리뷰해주시면 감사할 것 같습니다

### 구현사항

1. 실시간 인기 모임글 3개 + 더보기
2. 언어 맞춤 모임글 3개 + 더보기 
(1번 2번은 홈화면과 더보기 간 resDto가 달라 BaseResponse<?>로 api 리턴형식 고정하지 않고 서비스 함수도 각 2개씩 총 4개 생성)

3. 끌올로직을 쿨타임 기반에서 남은횟수 기반으로 변경 + 기존 끌올 및 단건조회 응답에 {끌올횟수/최대횟수} 정보 추가
4. 게시글 검색기능(검색 기준: 게시글 제목, 내용)
5. 게시글 목록에 맞춤언어 필터링 추가
6. 게시글 수정기능 + 이미지 url 변경분 s3 버킷 삭제 로직 추가
(category 제외 게시글 생성에서 작성했던 것들 다 변경 가능 + 모임시각 3시간 이내 기준 검증조건 추가)

7.  게시글 삭제기능  + s3 버킷 삭제 로직 추가
(post, meeting에 연관된 User 제외 모든 연관관계 수동삭제 <- why? Cascade 세팅을 우린 안하기로 초반에 결정했었음)

### 기존 구현 변경사항


1. 게시글에서 유저의 주/학습언어와 별개로 설정하는 모임 주/학습언어 속성 추가 및 단건조회 response에 반영
2. 게시글 목록/단건 조회에서 현재 로그인한 유저가 좋아요를 눌렀는지 정보를 프론트에 리턴 <- 1+N을 회피하기 위해 list 만들어서 sql in 문법 사용해 쿼리 1번으로 수행 << 이거 맛돌입니다
3. AWS S3 deleteObject에서 실제로 버킷에 삭제가 안되던 현상 수정 (why? 버킷정책에 삭제 정책 없었음 + 인코딩됐던 key값)
4. 게시글 모든 api을 로그인한 유저만 사용 가능한 것으로 변경 (모든 컨트롤러에 auth 인자 추가 why? 어차피 앱 사용 자체가 그래서)
5. 게시글 위치 정보를 주소 문자열 단 하나만으로 변경 
6. 모임 엔티티에서 setter 대신 사용하던 속성별 메서드 일괄 삭제 및 하나의 일괄변경 메서드로 수정 (게시글 수정 이외에서 속성이 개별적으로 변경될 일 없다 판단)
7. meeting fk로 그룹톡을 가져오던 jpa 매직 메서드를 테이블 연관관계(다대일) 맞춰 2개로 나누고 원래 쓰던 그룹톡 생성 서비스 함수 수정


closes #33 