### PR TITLE
feat: 사용자 역할 기반 관리자 접근 제어 기능 추가

### DIFF
--- a/src/main/java/org/glue/glue_be/auth/controller/AuthController.java
+++ b/src/main/java/org/glue/glue_be/auth/controller/AuthController.java
@@ -6,8 +6,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.auth.jwt.CustomUserDetails;
 import org.glue.glue_be.auth.service.AuthService;
 import org.glue.glue_be.common.response.BaseResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,6 +37,13 @@ public class AuthController {
 		@RequestParam("code") String code) {
 		authService.verifyCode(email, code);
 		return new BaseResponse<>(true);
+	}
+
+	@PatchMapping("/test/toggle-role")
+	@Operation(summary = "[테스트용] 로그인한 사용자의 역할 변경")
+	public BaseResponse<String> toggleRole(@AuthenticationPrincipal CustomUserDetails userDetails) {
+		String newRole = authService.toggleRole(userDetails.getUserId());
+		return new BaseResponse<>("변경된 역할: " + newRole);
 	}
 
 }

--- a/src/main/java/org/glue/glue_be/auth/jwt/CustomUserDetails.java
+++ b/src/main/java/org/glue/glue_be/auth/jwt/CustomUserDetails.java
@@ -1,44 +1,57 @@
 package org.glue.glue_be.auth.jwt;
 
+import java.util.List;
+import org.glue.glue_be.user.entity.UserRole;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
-import java.util.Collections;
 
 
 // Principal에 들어갈 유저 정보를 담고있는 객체
 public class CustomUserDetails implements UserDetails {
 
-	// 인증 객체에 들어갈 유저 정보들
-	private final Long userId;
-	private final String userNickName;
+    // 인증 객체에 들어갈 유저 정보들
+    private final Long userId;
+    private final String userNickName;
+    private final UserRole userRole;
 
-	public CustomUserDetails(Long userId, String userNickname) {
-		this.userId = userId;
-		this.userNickName = userNickname;
-	}
+    public CustomUserDetails(Long userId, String userNickname, UserRole userRole) {
+        this.userId = userId;
+        this.userNickName = userNickname;
+        this.userRole = userRole;
+    }
 
-	// Spring Security가 내부적으로 사용하는 용도
-	// 인터페이스 메서드는 getUsername이지만 실제로는 userId를 문자열로 리턴
-	@Override
-	public String getUsername() {
-		return String.valueOf(userId);
-	}
+    // Spring Security가 내부적으로 사용하는 용도
+    // 인터페이스 메서드는 getUsername이지만 실제로는 userId를 문자열로 리턴
+    @Override
+    public String getUsername() {
+        return String.valueOf(userId);
+    }
 
-	// 실제 비즈니스 로직에서 사용할 것
-	public Long getUserId() { return userId; }
+    // 실제 비즈니스 로직에서 사용할 것
+    public Long getUserId() {
+        return userId;
+    }
 
-	public String getUserNickname() { return userNickName; }
+    public String getUserNickname() {
+        return userNickName;
+    }
 
-	// 권한 로직이 아직 존재하지 않으므로 빈 리스트로 처리
-	@Override
-	public Collection<? extends GrantedAuthority> getAuthorities() { return Collections.emptyList(); }
+    public UserRole getRole() {
+        return userRole;
+    }
 
-	// 소셜 로그인 등으로 비밀번호를 쓰지 않을 경우 빈 문자열 리턴
-	@Override
-	public String getPassword() {
-		return "";
-	}
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(userRole.getAuthority()));
+    }
+
+    // 소셜 로그인 등으로 비밀번호를 쓰지 않을 경우 빈 문자열 리턴
+    @Override
+    public String getPassword() {
+        return "";
+    }
 
 }

--- a/src/main/java/org/glue/glue_be/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/glue/glue_be/auth/jwt/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.glue.glue_be.auth.response.AuthResponseStatus;
 import org.glue.glue_be.common.exception.BaseException;
+import org.glue.glue_be.user.entity.UserRole;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -46,17 +47,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			// 2. 만약 토큰이 유효한 토큰이라면
 			if (jwtTokenProvider.validateToken(token) == VALID_JWT) {
 
-				// 2-1. 토큰에서 userId, userNickname 추출
+				// 2-1. 토큰에서 userId, userNickname, role 추출
 				Long userId = jwtTokenProvider.getUserIdFromJwt(token);
 				String userNickname = jwtTokenProvider.getUserNicknameFromJwt(token);
+				UserRole role = jwtTokenProvider.getUserRoleFromJwt(token);
 
 				// 2-2. 유저정보를 담는 객체를 만들기 위해 userDetails 인터페이스에 따른 커스텀 객체를 초기화합니다.
-				CustomUserDetails userDetails = new CustomUserDetails(userId, userNickname);
+				CustomUserDetails userDetails = new CustomUserDetails(userId, userNickname, role);
 
 				// 유저 핵심정보를 넣는 principal은 추후 컨트롤러의 @AuthenticationPrincipal로 받게되는 타입이 됩니다.
 				// 따라서 우리가 컨트롤러에서 해당 어노테이션을 붙인 값의 타입은 CustomUserDetails가 돼야합니다!
 				UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-					userDetails, null, null
+					userDetails, null,  userDetails.getAuthorities()
 				);
 				auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 

--- a/src/main/java/org/glue/glue_be/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/glue/glue_be/auth/jwt/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.glue.glue_be.user.entity.UserRole;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -22,100 +23,109 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-	private static final String MEMBER_ID = "memberId";
-	private static final String MEMBER_NICKNAME = "memberNickname";
-	private static final Long TOKEN_EXPIRATION_TIME = 100 * 24 * 60 * 60 * 1000L; // todo: 토큰 유효기간 배포 시 원상복구 시키기
+    private static final String MEMBER_ID = "memberId";
+    private static final String MEMBER_NICKNAME = "memberNickname";
+    private static final String MEMBER_ROLE = "memberRole";
+    private static final Long TOKEN_EXPIRATION_TIME = 100 * 24 * 60 * 60 * 1000L; // todo: 토큰 유효기간 배포 시 원상복구 시키기
 
 
-	@Value("${jwt.secret}")
-	private String JWT_SECRET;
+    @Value("${jwt.secret}")
+    private String JWT_SECRET;
 
 
-	// 앱 실행 직전 jwt secret 키를 주입받은 후 base64로 인코딩하는 작업
-	// -> jjwt 라이브러리는 토큰이 base64 인코딩 문자열로 받아야해서 하는 작업
-	@PostConstruct // 해당 빈이 주입된 후 추가적인 초기화 작업할때 붙이는 어노테이션
-	protected void init() {
-		// base64 라이브러리에서 encodeToString을 이용해 byte[] -> String 타입으로 변환
-		JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
-	}
+    // 앱 실행 직전 jwt secret 키를 주입받은 후 base64로 인코딩하는 작업
+    // -> jjwt 라이브러리는 토큰이 base64 인코딩 문자열로 받아야해서 하는 작업
+    @PostConstruct // 해당 빈이 주입된 후 추가적인 초기화 작업할때 붙이는 어노테이션
+    protected void init() {
+        // base64 라이브러리에서 encodeToString을 이용해 byte[] -> String 타입으로 변환
+        JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
+    }
 
-	public String generateToken(Authentication authentication) {
+    public String generateToken(Authentication authentication) {
 
-		CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-		final Date now = new Date();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        final Date now = new Date();
 
-		// 1. 클레임 생성. jwt의 claims엔 여러개가 있는데 우선 토큰 발급시각과 토큰 만료시간 지정
-		final Claims claims = Jwts.claims()
-			.setIssuedAt(now)
-			.setExpiration(new Date(now.getTime() + TOKEN_EXPIRATION_TIME));
+        // 1. 클레임 생성. jwt의 claims엔 여러개가 있는데 우선 토큰 발급시각과 토큰 만료시간 지정
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + TOKEN_EXPIRATION_TIME));
 
-		// 2. userId와 nickname을 JWT 클레임에 삽입
-		claims.put(MEMBER_ID, userDetails.getUserId());
-		claims.put(MEMBER_NICKNAME, userDetails.getUserNickname());
+        // 2. userId와 nickname, role을 JWT 클레임에 삽입
+        claims.put(MEMBER_ID, userDetails.getUserId());
+        claims.put(MEMBER_NICKNAME, userDetails.getUserNickname());
+        claims.put(MEMBER_ROLE, userDetails.getRole());
 
-		// 3. header, 방금 조립한 claim, 그리고 signature을 합쳐 JWT 빌드
-		return Jwts.builder()
-			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-			.setClaims(claims)
-			.signWith(getSigningKey())
-			.compact();
-	}
-
-
-	// 서명 생성
-	private Key getSigningKey() {
-		// 1. jwt 비밀 키를 인코드 한 값을 가져옴
-		String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes());
-
-		// 2. 주어진 키 값을 기반으로 HMAC-SHA 암호화 알고리즘에 쓰이는 Key 객체 리턴
-		return Keys.hmacShaKeyFor(encodedKey.getBytes());
-	}
-
-	public JwtValidationType validateToken(String token) {
-		try {
-			final Claims claims = getBody(token);
-			return JwtValidationType.VALID_JWT;
-		} catch (MalformedJwtException ex) {
-			return JwtValidationType.INVALID_JWT_TOKEN;
-		} catch (ExpiredJwtException ex) {
-			return JwtValidationType.EXPIRED_JWT_TOKEN;
-		} catch (UnsupportedJwtException ex) {
-			return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
-		} catch (IllegalArgumentException ex) {
-			return JwtValidationType.EMPTY_JWT;
-		}
-	}
+        // 3. header, 방금 조립한 claim, 그리고 signature을 합쳐 JWT 빌드
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .signWith(getSigningKey())
+                .compact();
+    }
 
 
-	// claim 파싱 함수
-	private Claims getBody(final String token) {
-		return Jwts.parserBuilder()
-			.setSigningKey(getSigningKey())
-			.build()
-			.parseClaimsJws(token)
-			.getBody();
-	}
+    // 서명 생성
+    private Key getSigningKey() {
+        // 1. jwt 비밀 키를 인코드 한 값을 가져옴
+        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes());
 
-	// claim에서 유저 인증주체 정보 파싱 메서드
-	public Long getUserIdFromJwt(String token) {
-		Claims claims = getBody(token);
-		return Long.valueOf(claims.get(MEMBER_ID).toString());
-	}
+        // 2. 주어진 키 값을 기반으로 HMAC-SHA 암호화 알고리즘에 쓰이는 Key 객체 리턴
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());
+    }
 
-	public String getUserNicknameFromJwt(String token) {
-		Claims claims = getBody(token);
-		return claims.get(MEMBER_NICKNAME).toString();
-	}
+    public JwtValidationType validateToken(String token) {
+        try {
+            final Claims claims = getBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
 
-	public Authentication getAuthentication(String token) {
-		Long userId = getUserIdFromJwt(token);
-		String userNickname = getUserNicknameFromJwt(token);
 
-		// 사용자 정보를 기반으로 UserDetails 객체 생성
-		CustomUserDetails userDetails = new CustomUserDetails(userId, userNickname);
+    // claim 파싱 함수
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
 
-		// 인증 객체 생성 및 반환
-		return new UsernamePasswordAuthenticationToken(
-				userDetails, "", Collections.emptyList());
-	}
+    // claim에서 유저 인증주체 정보 파싱 메서드
+    public Long getUserIdFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.valueOf(claims.get(MEMBER_ID).toString());
+    }
+
+    public String getUserNicknameFromJwt(String token) {
+        Claims claims = getBody(token);
+        return claims.get(MEMBER_NICKNAME).toString();
+    }
+
+    public UserRole getUserRoleFromJwt(String token) {
+        Claims claims = getBody(token);
+        return UserRole.valueOf(claims.get(MEMBER_ROLE).toString());
+    }
+
+
+    public Authentication getAuthentication(String token) {
+        Long userId = getUserIdFromJwt(token);
+        String userNickname = getUserNicknameFromJwt(token);
+        UserRole role = getUserRoleFromJwt(token);
+
+        // 사용자 정보를 기반으로 UserDetails 객체 생성
+        CustomUserDetails userDetails = new CustomUserDetails(userId, userNickname, role);
+
+        // 인증 객체 생성 및 반환
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, "", userDetails.getAuthorities());
+    }
 }

--- a/src/main/java/org/glue/glue_be/main/controller/MainController.java
+++ b/src/main/java/org/glue/glue_be/main/controller/MainController.java
@@ -8,6 +8,7 @@ import org.glue.glue_be.main.dto.request.MainCarouselCreateRequest;
 import org.glue.glue_be.main.dto.response.*;
 import org.glue.glue_be.main.service.MainService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -27,10 +28,10 @@ public class MainController {
         return ResponseEntity.ok(response);
     }
 
-    // TODO: 관리자용 api들 관리자만 접근 가능하도록
     // 모든 버전 목록 조회 (관리자용)
     @GetMapping("/versions")
     @Operation(summary = "[관리자] 캐러셀 모든 버전 목록 조회")
+    @Secured(value = "ROLE_ADMIN")
     public ResponseEntity<CarouselVersionResponse> getAllVersions() {
         CarouselVersionResponse response = mainService.getAllVersions();
         return ResponseEntity.ok(response);
@@ -39,6 +40,7 @@ public class MainController {
     // 현재 배포 버전 조회 (관리자용)
     @GetMapping("/deploy-version")
     @Operation(summary = "[관리자] 현재 배포 중인 캐러셀 버전 조회")
+    @Secured(value = "ROLE_ADMIN")
     public String getCurrentDeployVersion() {
         return mainService.getCurrentDeployVersion();
     }
@@ -46,6 +48,7 @@ public class MainController {
     // 배포 버전 설정 (관리자용)
     @PostMapping("/deploy-version")
     @Operation(summary = "[관리자] 캐러셀 배포 버전 설정")
+    @Secured(value = "ROLE_ADMIN")
     public ResponseEntity<CarouselDeployVersionResponse> setDeployVersion(
             @RequestBody CarouselDeployVersionRequest request) {
         CarouselDeployVersionResponse response = mainService.setDeployVersion(request);
@@ -55,6 +58,7 @@ public class MainController {
     // 등록용 Presigned URL 생성 (관리자용)
     @PostMapping("/presigned-url")
     @Operation(summary = "[관리자] 캐러셀 이미지 등록용 Presigned URL 생성")
+    @Secured(value = "ROLE_ADMIN")
     public ResponseEntity<CarouselPresignedUrlResponse> createPresignedUrlForUpload(
             @RequestBody MainCarouselCreateRequest request) {
         CarouselPresignedUrlResponse response = mainService.createPresignedUrlForUpload(request);
@@ -64,6 +68,7 @@ public class MainController {
     // 버전별 일괄 삭제 (관리자용)
     @DeleteMapping("/version/{version}")
     @Operation(summary = "[관리자] 캐러셀 이미지 버전별 일괄 삭제")
+    @Secured(value = "ROLE_ADMIN")
     public ResponseEntity<CarouselBulkDeleteResponse> deleteCarouselsByVersion(@PathVariable String version) {
         CarouselBulkDeleteResponse response = mainService.deleteCarouselsByVersion(version);
         return ResponseEntity.ok(response);

--- a/src/main/java/org/glue/glue_be/notice/controller/NoticeController.java
+++ b/src/main/java/org/glue/glue_be/notice/controller/NoticeController.java
@@ -9,6 +9,7 @@ import org.glue.glue_be.common.response.BaseResponse;
 import org.glue.glue_be.notice.dto.request.NoticeRequest;
 import org.glue.glue_be.notice.dto.response.NoticeResponse;
 import org.glue.glue_be.notice.service.NoticeService;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,6 +21,7 @@ public class NoticeController {
     private final NoticeService noticeService;
     @PostMapping
     @Operation(summary = "[관리자] 공지 등록")
+    @Secured(value = "ROLE_ADMIN")
     public BaseResponse<NoticeResponse> create(@Valid @RequestBody NoticeRequest request) {
         NoticeResponse response = noticeService.create(request);
         return new BaseResponse<>(response);
@@ -27,6 +29,7 @@ public class NoticeController {
 
     @PutMapping("/{noticeId}")
     @Operation(summary = "[관리자] 공지 수정")
+    @Secured(value = "ROLE_ADMIN")
     public BaseResponse<NoticeResponse> update(@PathVariable Long noticeId, @Valid @RequestBody NoticeRequest request){
         NoticeResponse response = noticeService.update(noticeId, request);
         return new BaseResponse<>(response);
@@ -52,6 +55,7 @@ public class NoticeController {
 
     @DeleteMapping("/{noticeId}")
     @Operation(summary = "[관리자] 공지 삭제")
+    @Secured(value = "ROLE_ADMIN")
     public BaseResponse<Void> delete(@PathVariable Long noticeId){
         noticeService.delete(noticeId);
         return new BaseResponse<>();

--- a/src/main/java/org/glue/glue_be/notice/response/NoticeResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/notice/response/NoticeResponseStatus.java
@@ -9,7 +9,7 @@ import org.springframework.http.*;
 @AllArgsConstructor
 public enum NoticeResponseStatus implements ResponseStatus {
 
-    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 방명록입니다");
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 공지입니다");
 
 
     private final HttpStatusCode httpStatusCode;

--- a/src/main/java/org/glue/glue_be/notice/service/NoticeService.java
+++ b/src/main/java/org/glue/glue_be/notice/service/NoticeService.java
@@ -30,8 +30,6 @@ public class NoticeService {
 
     private final NotificationService notificationService;
 
-    // TODO: 작성, 수정, 삭제는 어드민만 가능
-
     // 공지사항 작성
     public NoticeResponse create(NoticeRequest request) {
 

--- a/src/main/java/org/glue/glue_be/report/controller/ReportReasonController.java
+++ b/src/main/java/org/glue/glue_be/report/controller/ReportReasonController.java
@@ -8,6 +8,7 @@ import org.glue.glue_be.common.response.BaseResponse;
 import org.glue.glue_be.report.dto.request.ReportReasonRequest;
 import org.glue.glue_be.report.dto.response.ReportReasonResponse;
 import org.glue.glue_be.report.service.ReportReasonService;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,10 +19,9 @@ public class ReportReasonController {
 
     private final ReportReasonService reportReasonService;
 
-    // TODO: [관리자] => 어드민만 접근 가능하게 하기
-
     @PostMapping
     @Operation(summary = "[관리자] 신고 사유 추가")
+    @Secured(value = "ROLE_ADMIN")
     public BaseResponse<ReportReasonResponse> create(@Valid @RequestBody ReportReasonRequest request) {
         ReportReasonResponse reason = reportReasonService.create(request);
         return new BaseResponse<>(reason);
@@ -29,6 +29,7 @@ public class ReportReasonController {
 
     @PutMapping("/{reportReasonId}")
     @Operation(summary = "[관리자] 신고 사유 수정")
+    @Secured(value = "ROLE_ADMIN")
     public BaseResponse<ReportReasonResponse> update(@PathVariable Long reportReasonId,
                                                      @Valid @RequestBody ReportReasonRequest request) {
         ReportReasonResponse reason = reportReasonService.update(reportReasonId, request);
@@ -45,6 +46,7 @@ public class ReportReasonController {
 
     @DeleteMapping("/{reportReasonId}")
     @Operation(summary = "[관리자] 신고 사유 삭제")
+    @Secured(value = "ROLE_ADMIN")
     public BaseResponse<Void> delete(@PathVariable Long reportReasonId) {
         reportReasonService.delete(reportReasonId);
         return new BaseResponse<>();

--- a/src/main/java/org/glue/glue_be/setting/SecurityConfig.java
+++ b/src/main/java/org/glue/glue_be/setting/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.glue.glue_be.auth.jwt.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -18,6 +19,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 @RequiredArgsConstructor // for DI fields
 @EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -22,6 +22,10 @@ public class User extends BaseEntity {
     @Column(name = "oauth_id", nullable = false, unique = true)
     private String oauthId;
 
+    @Convert(converter = UserRoleConverter.class)
+    @Column(name = "user_role", nullable = false)
+    private UserRole role;
+
     @Column(name = "real_name", nullable = false)
     private String realName;
 
@@ -88,7 +92,11 @@ public class User extends BaseEntity {
 
 
     @Builder
-    public User(String oauthId, String realName, String nickname, Integer gender, LocalDate birthDate, String description, Integer major, Integer school, String email, Integer systemLanguage, Integer languageMain, Integer languageLearn, Integer languageMainLevel, Integer languageLearnLevel, String profileImageUrl, Integer majorVisibility, Integer meetingVisibility, Integer likeVisibility, Integer guestbooksVisibility) {
+    public User(String oauthId, String realName, String nickname, Integer gender, LocalDate birthDate,
+                String description, Integer major, Integer school, String email, Integer systemLanguage,
+                Integer languageMain, Integer languageLearn, Integer languageMainLevel, Integer languageLearnLevel,
+                String profileImageUrl, Integer majorVisibility, Integer meetingVisibility, Integer likeVisibility,
+                Integer guestbooksVisibility) {
         this.oauthId = oauthId;
         this.realName = realName;
         this.nickname = nickname;
@@ -108,6 +116,7 @@ public class User extends BaseEntity {
         this.meetingVisibility = (meetingVisibility == null) ? VISIBILITY_PUBLIC : meetingVisibility;
         this.likeVisibility = (likeVisibility == null) ? VISIBILITY_PUBLIC : likeVisibility;
         this.guestbooksVisibility = (guestbooksVisibility == null) ? VISIBILITY_PUBLIC : guestbooksVisibility;
+        this.role = UserRole.ROLE_USER;
     }
 
 
@@ -171,6 +180,10 @@ public class User extends BaseEntity {
 
     public void changeGuestbooksVisibility(Integer guestbooksVisibility) {
         this.guestbooksVisibility = guestbooksVisibility;
+    }
+
+    public void changeRole(UserRole newRole) {
+        this.role = newRole;
     }
 
 }

--- a/src/main/java/org/glue/glue_be/user/entity/UserRole.java
+++ b/src/main/java/org/glue/glue_be/user/entity/UserRole.java
@@ -1,0 +1,26 @@
+package org.glue.glue_be.user.entity;
+
+public enum UserRole {
+    ROLE_USER(0, "USER"),
+    ROLE_ADMIN(1, "ADMIN");
+
+    private final int code;
+    private final String label;
+
+    UserRole(int code, String label) {
+        this.code = code;
+        this.label = label;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getAuthority() {
+        return name();
+    }
+}

--- a/src/main/java/org/glue/glue_be/user/entity/UserRoleConverter.java
+++ b/src/main/java/org/glue/glue_be/user/entity/UserRoleConverter.java
@@ -1,0 +1,27 @@
+package org.glue.glue_be.user.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class UserRoleConverter implements AttributeConverter<UserRole, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(UserRole attribute) {
+        return (attribute != null ? attribute.getCode() : null);
+    }
+
+    @Override
+    public UserRole convertToEntityAttribute(Integer dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        for (UserRole r : UserRole.values()) {
+            if (r.getCode() == dbData) {
+                return r;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown db role code: " + dbData);
+    }
+}

--- a/src/main/java/org/glue/glue_be/user/entity/UserRoleConverter.java
+++ b/src/main/java/org/glue/glue_be/user/entity/UserRoleConverter.java
@@ -2,6 +2,8 @@ package org.glue.glue_be.user.entity;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+import org.glue.glue_be.common.exception.BaseException;
+import org.glue.glue_be.user.response.UserResponseStatus;
 
 @Converter(autoApply = true)
 public class UserRoleConverter implements AttributeConverter<UserRole, Integer> {
@@ -22,6 +24,6 @@ public class UserRoleConverter implements AttributeConverter<UserRole, Integer> 
             }
         }
 
-        throw new IllegalArgumentException("Unknown db role code: " + dbData);
+        throw new BaseException(UserResponseStatus.INVALID_ROLE);
     }
 }

--- a/src/main/java/org/glue/glue_be/user/response/UserResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/user/response/UserResponseStatus.java
@@ -10,7 +10,8 @@ public enum UserResponseStatus implements ResponseStatus {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 사용자입니다"),
     ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 사용자가 존재합니다."),
-    NOT_OPEN(HttpStatus.FORBIDDEN, false, 403, "해당 정보는 사용자가 공개하지 않는 정보입니다");
+    NOT_OPEN(HttpStatus.FORBIDDEN, false, 403, "해당 정보는 사용자가 공개하지 않는 정보입니다"),
+    INVALID_ROLE(HttpStatus.BAD_REQUEST, false, 400, "잘못된 사용자 역할입니다");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/util/fcm/service/FcmService.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/service/FcmService.java
@@ -16,7 +16,14 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class FcmService {
 
+    // TODO: 개발 완료 후, 예외를 던지지 않도록 수정 예정
     public void sendMessage(FcmSendDto fcmSendDto) {
+        if (fcmSendDto.getToken() == null || fcmSendDto.getToken().isBlank()) {
+            log.error("[FCM 단일 전송 실패] 유효하지 않은 토큰: null 또는 빈 값");
+            throw new BaseException(FcmResponseStatus.FCM_SEND_ERROR, "FCM 토큰이 비어있습니다.");
+        }
+
+
         Message message = Message.builder()
                 .setNotification(Notification.builder()
                         .setTitle(fcmSendDto.getTitle())


### PR DESCRIPTION
### 주요 변경 사항

- `UserRole` enum 및 `UserRoleConverter` 추가
- `User` 엔티티에 `role` 필드 추가로 사용자 역할 구분
- `JWT`에 역할 정보 포함
- `@Secured` 기반의 관리자 전용 API 접근 제어 적용
- 테스트용 역할 토글 API 추가 (`/api/auth/test/toggle-role`)



closes #84 
