### PR TITLE
feat: 회원 탈퇴

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/dto/response/ChatResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/ChatResponseStatus.java
@@ -26,7 +26,8 @@ public enum ChatResponseStatus implements ResponseStatus {
     CHATROOM_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "채팅방 생성에 실패하였습니다"),
     MESSAGE_SENDING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "메시지 전송에 실패하였습니다"),
     MESSAGES_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "메시지 읽음 처리 실패하였습니다"),
-    INVITATION_STATUS_ERROR(HttpStatus.BAD_REQUEST, false, 400, "초대 상태를 확인할 수 없습니다");
+    INVITATION_STATUS_ERROR(HttpStatus.BAD_REQUEST, false, 400, "초대 상태를 확인할 수 없습니다"),
+    RECIPIENT_USER_DELETED(HttpStatus.FORBIDDEN, false, 403, "탈퇴한 사용자와는 메시지를 주고받을 수 없습니다");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean success;

--- a/src/main/java/org/glue/glue_be/chat/dto/response/DmChatRoomDetailResponse.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/DmChatRoomDetailResponse.java
@@ -37,6 +37,8 @@ public class DmChatRoomDetailResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    private Boolean isOtherUserDeleted;
+
     /**
      * JSON 직렬화 시 participants 또는 participantsWithHostInfo 중 하나만 사용
      * @return 적절한 참가자 목록

--- a/src/main/java/org/glue/glue_be/chat/mapper/DmResponseMapper.java
+++ b/src/main/java/org/glue/glue_be/chat/mapper/DmResponseMapper.java
@@ -30,7 +30,7 @@ public class DmResponseMapper {
     }
 
     //DmChatRoom 엔티티와 참여자 목록을 DmChatRoomDetailResponse DTO로 변환
-    public DmChatRoomDetailResponse toChatRoomDetailResponse(DmChatRoom dmChatRoom, List<DmUserChatroom> participants, Long userId, Integer invitationStatus) {
+    public DmChatRoomDetailResponse toChatRoomDetailResponse(DmChatRoom dmChatRoom, List<DmUserChatroom> participants, Long userId, Integer invitationStatus, Boolean isOtherUserDeleted) {
         List<UserSummary> participantResponses = participants.stream()
                 .map(dmUserChatroom -> toChatUserResponse(dmUserChatroom.getUser()))
                 .collect(Collectors.toList());
@@ -50,6 +50,7 @@ public class DmResponseMapper {
                     .orElse(1); //default: 1
 
             builder.isPushNotificationOn(isPushNotificationOn);
+            builder.isOtherUserDeleted(isOtherUserDeleted);
         }
 
         if (invitationStatus != -1) {

--- a/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
@@ -217,36 +217,6 @@ public abstract class CommonChatService {
                 .collect(Collectors.toList());
     }
 
-    // 메시지 db에 저장
-    protected <C, M, R> R saveMessage(
-            Long chatRoomId,
-            Long senderId,
-            String content,
-            Function<Long, C> chatRoomFinder,
-            BiFunction<C, User, ?> memberValidator,
-            TriFunction<C, User, String, M> messageCreator,
-            Function<M, M> messageSaver,
-            Function<M, R> responseMapper) {
-
-        try {
-            // 채팅방 정보 확인 -> 발신자 정보 확인 -> 해당 유저가 채팅방에 참여 중인지 확인
-            C chatRoom = chatRoomFinder.apply(chatRoomId);
-            User sender = getUserById(senderId);
-            memberValidator.apply(chatRoom, sender);
-
-            // 메시지 생성
-            M message = messageCreator.apply(chatRoom, sender, content);
-
-            // 메시지 저장
-            M savedMessage = messageSaver.apply(message);
-
-            // 응답 생성
-            return responseMapper.apply(savedMessage);
-        } catch (Exception e) {
-            throw new BaseException(ChatResponseStatus.MESSAGE_SENDING_FAILED);
-        }
-    }
-
     // 사용자의 웹소켓 연결 상태를 확인
     public boolean isUserConnectedToWebSocket(Long userId, String deliveryType) {
         // 사용자의 구독 주소 확인

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -34,6 +34,7 @@ public class DmChatService extends CommonChatService {
 
     final int INVITE_AVAILABLE = 1;
     final int INVITE_NOT_NECESSARY = -1;
+    final int INVITE_NOT_AVAILABLE = 3; // invitation 엔티티의 status 속성이 가질 수 있는 값 중 "fully used"값이 3이다.
     final boolean OTHER_USER_NOT_NECESSARY = false;
 
     private final DmChatRoomRepository dmChatRoomRepository;
@@ -120,8 +121,13 @@ public class DmChatService extends CommonChatService {
             Integer invitationStatus = INVITE_NOT_NECESSARY;
             Boolean isOtherUserDeleted = OTHER_USER_NOT_NECESSARY;
             if (userId.isPresent()) {
-                invitationStatus = checkInvitationStatus(dmChatRoom, participants, userId.get());
                 isOtherUserDeleted = checkIfRecipientDeleted(participants, userId.get());
+                if (isOtherUserDeleted) {
+                    // 대화 상대방이 탈퇴했다면 초대 불가
+                    invitationStatus = INVITE_NOT_AVAILABLE;
+                } else {
+                    invitationStatus = checkInvitationStatus(dmChatRoom, participants, userId.get());
+                }
             }
 
             // 아직 초대장이 한 번도 안 만들어진 상태일 때: 무조건 초대 가능하도록

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -505,9 +505,9 @@ public class DmChatService extends CommonChatService {
 
     private Long getCurrentUserLastReadMessageId(Long userId, Long chatroomId) {
         return dmUserChatroomRepository
-                .findByUser_UserIdAndDmChatRoom_Id(userId, chatroomId)  // Repository 메소드명 수정
-                .map(DmUserChatroom::getLastReadMessageId)              // getId() -> getLastReadMessageId()
-                .orElse(0L);                                            // Optional 처리
+                .findByUser_UserIdAndDmChatRoom_Id(userId, chatroomId)
+                .map(DmUserChatroom::getLastReadMessageId)
+                .orElse(0L);
     }
 
     private Long getLatestMessageId(DmChatRoom chatRoom) {

--- a/src/main/java/org/glue/glue_be/guestbook/repository/GuestBookRepository.java
+++ b/src/main/java/org/glue/glue_be/guestbook/repository/GuestBookRepository.java
@@ -27,4 +27,6 @@ public interface GuestBookRepository extends JpaRepository<GuestBook, Long> {
     );
 
     Long countByHost_UserId(Long userId);
+
+    void deleteByHost_UserId(Long userId);
 }

--- a/src/main/java/org/glue/glue_be/meeting/response/MeetingResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/meeting/response/MeetingResponseStatus.java
@@ -17,7 +17,8 @@ public enum MeetingResponseStatus implements ResponseStatus {
     ALREADY_JOINED(HttpStatus.CONFLICT, false, 409, "이미 모임에 참여 중입니다"),
     NON_PARTICIPANT_INVITATION(HttpStatus.FORBIDDEN, false, 403, "모임 참가자만 초대장을 생성할 수 있습니다"),
     NOT_HOST_PERMISSION(HttpStatus.FORBIDDEN, false, 403, "모임 주최자만 이 작업을 수행할 수 있습니다"),
-    NOT_JOINED(HttpStatus.FORBIDDEN, false, 403, "모임에 참여하지 않은 사용자입니다");
+    NOT_JOINED(HttpStatus.FORBIDDEN, false, 403, "모임에 참여하지 않은 사용자입니다"),
+    MEETING_HOST_DELETED(HttpStatus.FORBIDDEN, false, 403, "탈퇴한 사용자가 주최한 모임에는 참여할 수 없습니다");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/meeting/service/MeetingService.java
+++ b/src/main/java/org/glue/glue_be/meeting/service/MeetingService.java
@@ -16,6 +16,8 @@ import org.glue.glue_be.user.response.UserResponseStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.glue.glue_be.user.entity.User.IS_DELETED;
+
 
 @Service
 @RequiredArgsConstructor
@@ -77,11 +79,13 @@ public class MeetingService {
      */
     @Transactional
     public void joinMeeting(Long meetingId, Long userId) {
-        // 모임 존재 확인
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new BaseException(MeetingResponseStatus.MEETING_NOT_FOUND));
 
-        // 사용자 존재 확인
+        if (meeting.getHost().getIsDeleted().equals(IS_DELETED)) {
+            throw new BaseException(MeetingResponseStatus.MEETING_HOST_DELETED);
+        }
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(UserResponseStatus.USER_NOT_FOUND));
 

--- a/src/main/java/org/glue/glue_be/user/controller/UserController.java
+++ b/src/main/java/org/glue/glue_be/user/controller/UserController.java
@@ -31,21 +31,21 @@ public class UserController {
 		return new BaseResponse<>(response);
 	}
 
-	//	// 2-1. 내 언어/수준 변경
+	// 2-1. 내 언어/수준 변경
 	@PutMapping("/main-language")
 	public BaseResponse<Void> updateMainLanguage(@AuthenticationPrincipal CustomUserDetails auth, @Valid @RequestBody UpdateLanguageRequest request) {
 		userService.updateMainLanguage(auth.getUserId(), request);
 		return new BaseResponse<>();
 	}
 
-	//	// 2-2. 학습 언어/수준 변경
+	// 2-2. 학습 언어/수준 변경
 	@PutMapping("/learning-language")
 	public BaseResponse<Void> updateLearningLanguage(@AuthenticationPrincipal CustomUserDetails auth, @Valid @RequestBody UpdateLanguageRequest request) {
 		userService.updateLearningLanguage(auth.getUserId(), request);
 		return new BaseResponse<>();
 	}
 
-	//	// 3. 프로필 조회 (본인)
+	// 3. 프로필 조회 (본인)
 	@GetMapping("/profile/me")
 	public BaseResponse<MyProfileResponse> getMyProfile(@AuthenticationPrincipal CustomUserDetails auth) {
 		MyProfileResponse response = userService.getMyProfile(auth.getUserId());
@@ -132,7 +132,11 @@ public class UserController {
 		return new BaseResponse<>();
 	}
 
-
-
+	// 15. 회원 탈퇴
+	@PutMapping("/signout")
+	public BaseResponse<Void> signOut(@AuthenticationPrincipal CustomUserDetails auth) {
+		userService.signOut(auth.getUserId());
+		return new BaseResponse<>();
+	}
 
 }

--- a/src/main/java/org/glue/glue_be/user/controller/UserController.java
+++ b/src/main/java/org/glue/glue_be/user/controller/UserController.java
@@ -152,6 +152,7 @@ public class UserController {
 
 	// 15. 회원 탈퇴
 	@PutMapping("/signout")
+	@Operation(summary = "회원 탈퇴")
 	public BaseResponse<Void> signOut(@AuthenticationPrincipal CustomUserDetails auth) {
 		userService.signOut(auth.getUserId());
 		return new BaseResponse<>();

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -14,6 +14,15 @@ import org.glue.glue_be.common.config.LocalDateStringConverter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
+    public static final int SYSTEM_LANGUAGE_KOREAN = 1;
+    public static final int SYSTEM_LANGUAGE_ENGLISH = 2;
+
+    public static final int VISIBILITY_PUBLIC = 1;
+    public static final int VISIBILITY_PRIVATE = 0;
+
+    public static final int IS_NOT_DELETED = 0;
+    public static final int IS_DELETED = 1;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -62,17 +71,11 @@ public class User extends BaseEntity {
     @Column(name = "language_learn_level", nullable = false) // default = 3
     private Integer languageLearnLevel;
 
-    public static final int SYSTEM_LANGUAGE_KOREAN = 1;
-    public static final int SYSTEM_LANGUAGE_ENGLISH = 2;
-
     @Column(name = "system_language", nullable = false) // default = 1
     private Integer systemLanguage;
 
     @Column(name = "fcm_token")
     private String fcmToken;
-
-    public static final int VISIBILITY_PUBLIC = 1;
-    public static final int VISIBILITY_PRIVATE = 0;
 
     @Column(name = "major_visibility", nullable = false) // default = 1
     private Integer majorVisibility;
@@ -85,6 +88,9 @@ public class User extends BaseEntity {
 
     @Column(name = "guestbooks_visibility", nullable = false) // default = 1
     private Integer guestbooksVisibility;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Integer isDeleted;
 
 
     @Builder
@@ -108,6 +114,7 @@ public class User extends BaseEntity {
         this.meetingVisibility = (meetingVisibility == null) ? VISIBILITY_PUBLIC : meetingVisibility;
         this.likeVisibility = (likeVisibility == null) ? VISIBILITY_PUBLIC : likeVisibility;
         this.guestbooksVisibility = (guestbooksVisibility == null) ? VISIBILITY_PUBLIC : guestbooksVisibility;
+        this.isDeleted = IS_NOT_DELETED;
     }
 
 
@@ -174,6 +181,9 @@ public class User extends BaseEntity {
     }
 
     public void anonymizeForSignOut() {
+        // 탈퇴
+        this.isDeleted = IS_DELETED;
+
         // not null 필드들을 기본값으로 설정
         this.birthDate = LocalDate.parse("1900-01-01T00:00:00");
         this.email = "deleted@deleted.com";

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -198,7 +198,7 @@ public class User extends BaseEntity {
         this.majorVisibility = -1;
         this.meetingVisibility = -1;
         this.nickname = "탈퇴한 사용자_" + this.userId;
-        this.oauthId = "deleted_oauth_id_" + this.userId;
+        this.oauthId = "deleted_oauth_id_" + this.oauthId;
         this.school = -1;
         this.systemLanguage = -1;
 

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -185,7 +185,7 @@ public class User extends BaseEntity {
         this.isDeleted = IS_DELETED;
 
         // not null 필드들을 기본값으로 설정
-        this.birthDate = LocalDate.parse("1900-01-01T00:00:00");
+        this.birthDate = LocalDate.parse("1900-01-01");
         this.email = "deleted@deleted.com";
         this.gender = -1;
         this.guestbooksVisibility = VISIBILITY_PRIVATE;

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -173,4 +173,29 @@ public class User extends BaseEntity {
         this.guestbooksVisibility = guestbooksVisibility;
     }
 
+    public void anonymizeForSignOut() {
+        // not null 필드들을 기본값으로 설정
+        this.birthDate = LocalDate.parse("1900-01-01T00:00:00");
+        this.email = "deleted@deleted.com";
+        this.gender = -1;
+        this.guestbooksVisibility = VISIBILITY_PRIVATE;
+        this.languageLearn = -1;
+        this.languageLearnLevel = -1;
+        this.languageMain = -1;
+        this.languageMainLevel = -1;
+        this.likeVisibility = VISIBILITY_PRIVATE;
+        this.major = -1;
+        this.majorVisibility = -1;
+        this.meetingVisibility = -1;
+        this.nickname = "탈퇴한 사용자_" + this.userId;
+        this.oauthId = "deleted_oauth_id_" + this.userId;
+        this.school = -1;
+        this.systemLanguage = -1;
+
+        // nullable 필드들을 null로 설정
+        this.description = null;
+        this.fcmToken = null;
+        this.profileImageUrl = null;
+        this.realName = null;
+    }
 }

--- a/src/main/java/org/glue/glue_be/user/entity/User.java
+++ b/src/main/java/org/glue/glue_be/user/entity/User.java
@@ -190,7 +190,7 @@ public class User extends BaseEntity {
     }
 
     public void anonymizeForSignOut() {
-        // 탈퇴
+        // soft delete
         this.isDeleted = IS_DELETED;
 
         // not null 필드들을 기본값으로 설정

--- a/src/main/java/org/glue/glue_be/user/response/UserResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/user/response/UserResponseStatus.java
@@ -10,7 +10,10 @@ public enum UserResponseStatus implements ResponseStatus {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 사용자입니다"),
     ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 사용자가 존재합니다."),
-    NOT_OPEN(HttpStatus.FORBIDDEN, false, 403, "해당 정보는 사용자가 공개하지 않는 정보입니다");
+    NOT_OPEN(HttpStatus.FORBIDDEN, false, 403, "해당 정보는 사용자가 공개하지 않는 정보입니다"),
+    CANNOT_DELETE_WITH_ACTIVE_MEETINGS(HttpStatus.CONFLICT, false, 409, "호스트로서 진행 중인 모임이 있어 탈퇴할 수 없습니다");
+
+
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/src/main/java/org/glue/glue_be/user/service/UserService.java
+++ b/src/main/java/org/glue/glue_be/user/service/UserService.java
@@ -191,6 +191,13 @@ public class UserService {
 		user.changeDescription(description);
 	}
 
+	// 15. 회원 탈퇴
+	public void signOut(Long userId) {
+		User user = getUserById(userId);
+		user.anonymizeForSignOut();
+	}
+
+
 
 
 	// 공용: 공용 유저 조회 메서드

--- a/src/main/java/org/glue/glue_be/user/service/UserService.java
+++ b/src/main/java/org/glue/glue_be/user/service/UserService.java
@@ -4,6 +4,7 @@ package org.glue.glue_be.user.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.glue.glue_be.common.exception.BaseException;
+import org.glue.glue_be.meeting.repository.MeetingRepository;
 import org.glue.glue_be.post.dto.response.GetLikedPostsResponse;
 import org.glue.glue_be.post.entity.Like;
 import org.glue.glue_be.post.entity.Post;
@@ -32,6 +33,7 @@ public class UserService {
 	private final UserRepository userRepository;
 	private final LikeRepository likeRepository;
 	private final PostRepository postRepository;
+	private final MeetingRepository meetingRepository;
 
 
 
@@ -194,6 +196,11 @@ public class UserService {
 	// 15. 회원 탈퇴
 	public void signOut(Long userId) {
 		User user = getUserById(userId);
+
+		if (!meetingRepository.findByHost_UserId(userId).isEmpty()) {
+			throw new BaseException(UserResponseStatus.CANNOT_DELETE_WITH_ACTIVE_MEETINGS);
+		}
+
 		user.anonymizeForSignOut();
 	}
 

--- a/src/main/java/org/glue/glue_be/user/service/UserService.java
+++ b/src/main/java/org/glue/glue_be/user/service/UserService.java
@@ -4,6 +4,7 @@ package org.glue.glue_be.user.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.glue.glue_be.common.exception.BaseException;
+import org.glue.glue_be.guestbook.repository.GuestBookRepository;
 import org.glue.glue_be.meeting.repository.MeetingRepository;
 import org.glue.glue_be.post.dto.response.GetLikedPostsResponse;
 import org.glue.glue_be.post.entity.Like;
@@ -34,6 +35,7 @@ public class UserService {
 	private final LikeRepository likeRepository;
 	private final PostRepository postRepository;
 	private final MeetingRepository meetingRepository;
+	private final GuestBookRepository guestBookRepository;
 
 
 
@@ -197,11 +199,16 @@ public class UserService {
 	public void signOut(Long userId) {
 		User user = getUserById(userId);
 
+		// 호스트로서 진행 중인 모임이 있으면 탈퇴 불가
 		if (!meetingRepository.findByHost_UserId(userId).isEmpty()) {
 			throw new BaseException(UserResponseStatus.CANNOT_DELETE_WITH_ACTIVE_MEETINGS);
 		}
 
+		// soft delete 및 개인정보 익명화
 		user.anonymizeForSignOut();
+
+		// 해당 유저의 방명록 모두 삭제
+		guestBookRepository.deleteByHost_UserId(userId);
 	}
 
 


### PR DESCRIPTION
## 1) 회원 탈퇴 로직 추가했습니다.
   - #80 에서 논의한 바와 같이 데이터 익명화 처리했습니다.
   - 사용자의 탈퇴 여부를 추적해야 하는 상황이 몇 있었는데, `is_deleted` 속성을 추가하여 추적에 더 용이하도록 했습니다.
## 2) 회원 탈퇴에 따라 앱 흐름상 별도 처리 필요한 부분들에 대해 처리했습니다. 코드는 어렵지 않은데, 혹시 탈퇴에 대해 추가 처리해야 하는 부분 있을 것 같으면 말씀해주세용!
   ### 1. 탈퇴한 회원이 주최하고 있는 미팅 참여 불가능하도록 했습니다.
- 403 에러를 내뿜도록 했습니다.
### 2. 탈퇴한 회원과의 쪽지를 주고 받지 못하도록 처리했습니다.
- 총 두 번 막습니다.
   - 채팅방 상세 정보를 불러올 때: dto의 `isOtherUserDeleted` 값을 넘깁니다.
   - 채팅 보내려고 할 때: 403에러를 내뿜도록 했습니다.
### 3. 탈퇴하고자 하는 회원이 현재 주최하고 있는 미팅이 있을 떄, 탈퇴하지 못하도록 했습니다.
- 409 에러를 내뿜도록 했습니다.
   - 409인 이유: 사용자가 탈퇴하려고 하지만 현재 상태(진행 중인 모임 보유)와 충돌이 발생하는 상황이기 때문입니다.
### 4. 쪽지에서 대화 상대방이 탈퇴해버렸다면, 모임에 초대할 수 없게 했습니다.
- 왼쪽 그림처럼 아예 초대 버튼이 없애는 게 좋을지, 오른쪽 그림처럼 초대 버튼은 있되 비활성화 하는 값을 넘길지 고민하다가, 후자의 방법을 채택했습니다.
 <img width="697" alt="image" src="https://github.com/user-attachments/assets/c82bfc3b-2580-4f56-8f65-419fe16a3dd9" />



close #80 