### PR TITLE
fix: 메시지 목록 조회 시 업데이트 순으로 조회되도록 정렬 기준 변경 + 게시글 생성 시 현재 참여 인원 2명으로 저장되던 버그 해결

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/entity/dm/DmChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/dm/DmChatRoom.java
@@ -35,4 +35,7 @@ public class DmChatRoom extends BaseEntity {
 		dmUserChatroom.updateChatRoom(this);
 	}
 
+	public void updateLastActivity() {
+		this.touchUpdatedAt();
+	}
 }

--- a/src/main/java/org/glue/glue_be/chat/repository/dm/DmChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/dm/DmChatRoomRepository.java
@@ -1,7 +1,6 @@
 package org.glue.glue_be.chat.repository.dm;
 
 import org.glue.glue_be.chat.entity.dm.DmChatRoom;
-import org.glue.glue_be.meeting.entity.Meeting;
 import org.glue.glue_be.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -26,12 +25,16 @@ public interface DmChatRoomRepository extends JpaRepository<DmChatRoom, Long> {
             @Param("userId1") Long userId1,
             @Param("userId2") Long userId2);
 
-    // 호스트 기준 첫 페이지 조회
-    List<DmChatRoom> findByMeetingHostOrderByIdDesc(User host, Pageable pageable);
-
-    // 호스트 기준 커서 조회
-    List<DmChatRoom> findByMeetingHostAndIdLessThanOrderByIdDesc(User host, Long cursorId, Pageable pageable);
-
 	List<DmChatRoom> findByMeeting_MeetingId(Long meetingMeetingId);
+
+    // 첫 페이지 조회
+    List<DmChatRoom> findByMeetingHostOrderByUpdatedAtDesc(User host, Pageable pageable);
+
+    // 커서 기반 조회 - LocalDateTime 파라미터 사용
+    @Query("SELECT dcr FROM DmChatRoom dcr WHERE dcr.meeting.host = :host AND dcr.id < :cursorId ORDER BY dcr.updatedAt DESC")
+    List<DmChatRoom> findByMeetingHostAndUpdatedAtLessThanOrderByUpdatedAtDesc(
+            @Param("host") User host,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable);
 
 }

--- a/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
@@ -31,16 +31,16 @@ public interface DmUserChatroomRepository extends JpaRepository<DmUserChatroom, 
     @Query(value = "SELECT DISTINCT dc.* FROM dm_chatroom dc " +
             "JOIN dm_user_chatroom duc ON dc.dm_chatroom_id = duc.dm_chatroom_id " +
             "WHERE duc.user_id = :userId " +
-            "ORDER BY dc.dm_chatroom_id DESC",
+            "ORDER BY dc.updated_at DESC",
             nativeQuery = true)
-    List<DmChatRoom> findDmChatRoomsByUserOrderByDmChatRoomIdDesc(@Param("userId") Long userId, Pageable pageable);
+    List<DmChatRoom> findDmChatRoomsByUserOrderByUpdatedAtDesc(@Param("userId") Long userId, Pageable pageable);
 
     @Query(value = "SELECT DISTINCT dc.* FROM dm_chatroom dc " +
             "JOIN dm_user_chatroom duc ON dc.dm_chatroom_id = duc.dm_chatroom_id " +
             "WHERE duc.user_id = :userId AND dc.dm_chatroom_id < :cursorId " +
-            "ORDER BY dc.dm_chatroom_id DESC",
+            "ORDER BY dc.updated_at DESC",
             nativeQuery = true)
-    List<DmChatRoom> findDmChatRoomsByUserAndDmChatRoomIdLessThanOrderByDmChatRoomIdDesc(@Param("userId") Long userId, @Param("cursorId") Long cursorId, Pageable pageable);
+    List<DmChatRoom> findDmChatRoomsByUserAndDmChatRoomIdLessThanOrderByUpdatedAtDesc(@Param("userId") Long userId, @Param("cursorId") Long cursorId, Pageable pageable);
 
     Optional<DmUserChatroom> findByUser_UserIdAndDmChatRoom_Id(Long userId, Long dmChatRoomId);
 

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -253,8 +253,8 @@ public class DmChatService extends CommonChatService {
                     pageSize,
                     userId,
                     this::getUserById,
-                    (user, pageable) -> dmUserChatroomRepository.findDmChatRoomsByUserOrderByDmChatRoomIdDesc(user.getUserId(), pageable),
-                    (user, curId, pageable) -> dmUserChatroomRepository.findDmChatRoomsByUserAndDmChatRoomIdLessThanOrderByDmChatRoomIdDesc(user.getUserId(), curId, pageable),
+                    (user, pageable) -> dmUserChatroomRepository.findDmChatRoomsByUserOrderByUpdatedAtDesc(user.getUserId(), pageable),
+                    (user, curId, pageable) -> dmUserChatroomRepository.findDmChatRoomsByUserAndDmChatRoomIdLessThanOrderByUpdatedAtDesc(user.getUserId(), curId, pageable),
                     (chatRooms, user) -> {
                         // 내가 호스트가 아닌 미팅의 DM 채팅방만 필터링 후 변환
                         List<DmChatRoom> filteredChatRooms = chatRooms.stream()

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -233,8 +233,8 @@ public class DmChatService extends CommonChatService {
                     pageSize,
                     userId,
                     this::getUserById,
-                    dmChatRoomRepository::findByMeetingHostOrderByIdDesc,
-                    dmChatRoomRepository::findByMeetingHostAndIdLessThanOrderByIdDesc,
+                    dmChatRoomRepository::findByMeetingHostOrderByUpdatedAtDesc,
+                    dmChatRoomRepository::findByMeetingHostAndUpdatedAtLessThanOrderByUpdatedAtDesc,
                     this::convertToChatRoomResponses
             );
         } catch (BaseException e) {
@@ -432,6 +432,8 @@ public class DmChatService extends CommonChatService {
                     .build();
 
             DmMessage savedMessage = dmMessageRepository.save(message);
+            chatRoom.updateLastActivity();
+
             return responseMapper.toMessageResponse(savedMessage);
         } catch (BaseException e) {
             throw e;

--- a/src/main/java/org/glue/glue_be/common/BaseEntity.java
+++ b/src/main/java/org/glue/glue_be/common/BaseEntity.java
@@ -18,4 +18,8 @@ abstract public class BaseEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    public void touchUpdatedAt() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/org/glue/glue_be/post/service/PostService.java
+++ b/src/main/java/org/glue/glue_be/post/service/PostService.java
@@ -93,7 +93,7 @@ public class PostService {
 			.meetingPlaceName(meetingRequest.getMeetingPlaceName())
 			.minParticipants(0) // 1.0에선 최소인원이 안쓰이기에 일단 0으로 고정
 			.maxParticipants(meetingRequest.getMaxParticipants())
-			.currentParticipants(1)
+			.currentParticipants(0)
 			.status(1)
 			.categoryId(meetingRequest.getCategoryId())
 			.meetingMainLanguageId(meetingRequest.getMainLanguageId())


### PR DESCRIPTION
## 1. (DM) 메시지 목록 조회 시 업데이트 순으로 조회되도록 정렬 기준 변경
- 추후 메시지 목록에도 소켓을 적용하기 위한 밑작업입니다.
- 메시지를 전송할 때마다 해당 채팅방의 updatedAt도 메시지 전송 시각으로 수정되도록 하는 코드 추가했습니다.
- 그룹도 곧 동일 로직 적용 예정입니다.

## 2. 게시글 생성 시 현재 참여 인원 2명으로 저장되던 버그 해결
- postService.java의 createPost 매소드에서
```
Meeting meeting = Meeting.builder() 
	// ...
	.currentParticipants(1) // 여기서 현재 인원을 한 명이라고 하고
	// ...

// 여기서 참여자를 한 명 더 추가하여 current_participant 속성에 한 명인데 두 명으로 저장되던 문제 발생
savedMeeting.addParticipant(participant); 
```

- `addParticipant` 내부 로직에 `currentParticipants++`가 있어서 발생했었습니다.
```
public void addParticipant(Participant participant) {
        this.participants.add(participant);
        this.currentParticipants++;
        participant.updateMeeting(this);
    }
```

따라서, `.currentParticipants(0)`으로 바꿈