### PR TITLE
fix: 기존 방명록 조회에서 본인 방명록 조회는 공개여부 체크 로직 패스 추

### DIFF
--- a/src/main/java/org/glue/glue_be/guestbook/service/GuestBookService.java
+++ b/src/main/java/org/glue/glue_be/guestbook/service/GuestBookService.java
@@ -102,8 +102,10 @@ public class GuestBookService {
         // 1) 호스트 존재 확인
         User user = findUser(hostId);
 
-        // 1.5) 호스트가 방명록을 공개하고있지 않다면 빠꾸
-        if(user.getGuestbooksVisibility() == User.VISIBILITY_PRIVATE) throw new BaseException(UserResponseStatus.NOT_OPEN);
+        // 1.5) 본인이 아니고, 호스트가 방명록을 공개하고있지 않다면 빠꾸
+        if(!hostId.equals(currentUserId) && user.getGuestbooksVisibility() == User.VISIBILITY_PRIVATE) {
+            throw new BaseException(UserResponseStatus.NOT_OPEN);
+        }
 
         // 2) 부모 댓글만 pageSize+1 건 조회 (커서 페이징)
         Pageable pageable = PageRequest.of(0, pageSize + 1);


### PR DESCRIPTION
본인 방명록 조회는 공개여부 검증 로직을 회피하도록 조건문을 변경했습니다


<img width="652" alt="image" src="https://github.com/user-attachments/assets/95be73d7-d77b-49bc-9658-364c16950c66" />
