### PR TITLE
feat: FCM 전송 실패 시 채팅 전송 성공하도록 예외 처리 추가

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/CommonChatService.java
@@ -339,8 +339,16 @@ public abstract class CommonChatService {
                     content
             );
 
-            // 알림 전송
-            notificationSender.accept(notification);
+            // 알림 전송 (FCM 전송 실패 시에도 채팅 전송은 성공하도록 예외 처리)
+            try {
+                notificationSender.accept(notification);
+            } catch (Exception e) {
+                log.error("[FCM 전송 실패] 수신자: {}, 제목: {}, 내용: {}, 오류: {}", 
+                    recipientUser.getNickname(), 
+                    notification.toString(), 
+                    content, 
+                    e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
sendPushNotificationsToOfflineReceivers 메서드에서 푸시 알림 전송 실패에 대한 오류 처리를 추가하여, 알림 전송이 실패하더라도 채팅 메시지 전달에는 영향을 주지 않도록 하는 개선사항입니다.
푸시 알림 오류 처리 추가:

[src/main/java/org/glue/glue_be/chat/service/CommonChatService.java](diffhunk://#diff-de1c40540266b1e1728861bab31d38fc8da2c1f18d5215c707b7088bf6a91a60L342-R351): notificationSender.accept(notification) 호출을 try-catch 블록으로 감싸서 예외를 처리하도록 했습니다. FCM(Firebase Cloud Messaging) 알림 전송 중 오류가 발생하면, 수신자, 알림, 내용, 오류 메시지에 대한 세부 정보와 함께 실패 로그를 기록하되, 채팅 메시지 전달은 중단되지 않도록 보장합니다.