### PR TITLE
feat: FCM 알림에 type, id, guestbookHostId 필드 추가

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
@@ -52,8 +52,8 @@ public class GroupChatService extends CommonChatService {
             if (groupChatRoomRepository.existsByMeeting_MeetingId(meetingId)) {
                 // 기존 채팅방이 있으면 사용자만 추가
                 GroupChatRoom chatRoom = groupChatRoomRepository
-                    .findFirstByMeeting_MeetingId(meetingId)
-                    .orElseThrow(() -> new BaseException(ChatResponseStatus.CHATROOM_NOT_FOUND));
+                        .findFirstByMeeting_MeetingId(meetingId)
+                        .orElseThrow(() -> new BaseException(ChatResponseStatus.CHATROOM_NOT_FOUND));
 
                 // 이미 사용자가 채팅방에 참여 중인지 확인
                 Optional<GroupUserChatRoom> existingUserChatroom =
@@ -63,7 +63,8 @@ public class GroupChatService extends CommonChatService {
                     // 이미 참여 중이면 기존 채팅방 정보 반환
                     return new GroupChatRoomCreateResult(
                             getGroupChatRoomDetail(chatRoom.getGroupChatroomId(), userId),
-                            new ActionResponse(ChatResponseStatus.CHATROOM_JOINED.getCode(), ChatResponseStatus.CHATROOM_JOINED.getMessage())
+                            new ActionResponse(ChatResponseStatus.CHATROOM_JOINED.getCode(),
+                                    ChatResponseStatus.CHATROOM_JOINED.getMessage())
                     );
                 } else {
                     // 채팅방에 사용자 추가
@@ -72,7 +73,8 @@ public class GroupChatService extends CommonChatService {
 
                     return new GroupChatRoomCreateResult(
                             getGroupChatRoomDetail(chatRoom.getGroupChatroomId(), userId),
-                            new ActionResponse(ChatResponseStatus.CHATROOM_JOINED.getCode(), ChatResponseStatus.CHATROOM_JOINED.getMessage())
+                            new ActionResponse(ChatResponseStatus.CHATROOM_JOINED.getCode(),
+                                    ChatResponseStatus.CHATROOM_JOINED.getMessage())
                     );
                 }
             } else {
@@ -91,7 +93,8 @@ public class GroupChatService extends CommonChatService {
 
                 return new GroupChatRoomCreateResult(
                         getGroupChatRoomDetail(savedChatRoom.getGroupChatroomId(), userId),
-                        new ActionResponse(ChatResponseStatus.CHATROOM_CREATED.getCode(), ChatResponseStatus.CHATROOM_CREATED.getMessage())
+                        new ActionResponse(ChatResponseStatus.CHATROOM_CREATED.getCode(),
+                                ChatResponseStatus.CHATROOM_CREATED.getMessage())
                 );
             }
         } catch (BaseException e) {
@@ -190,7 +193,8 @@ public class GroupChatService extends CommonChatService {
         }
     }
 
-    private List<GroupChatRoomListResponse> convertToGroupChatRoomResponses(List<GroupChatRoom> chatRooms, User currentUser) {
+    private List<GroupChatRoomListResponse> convertToGroupChatRoomResponses(List<GroupChatRoom> chatRooms,
+                                                                            User currentUser) {
         return chatRooms.stream()
                 .map(chatRoom -> {
                     // 참여자 수 계산
@@ -198,11 +202,13 @@ public class GroupChatService extends CommonChatService {
                     int participantCount = participants.size();
 
                     // 최근 메시지 조회
-                    GroupMessage lastMessage = groupMessageRepository.findTopByGroupChatroomOrderByCreatedAtDesc(chatRoom)
+                    GroupMessage lastMessage = groupMessageRepository.findTopByGroupChatroomOrderByCreatedAtDesc(
+                                    chatRoom)
                             .orElse(null);
 
                     // 현재 사용자의 마지막 읽은 메시지 ID 조회
-                    Long currentUserLastReadMessageId = getCurrentUserLastReadMessageId(currentUser.getUserId(), chatRoom.getGroupChatroomId());
+                    Long currentUserLastReadMessageId = getCurrentUserLastReadMessageId(currentUser.getUserId(),
+                            chatRoom.getGroupChatroomId());
 
                     // 채팅방의 가장 최신 메시지 ID 조회
                     long latestMessageId = lastMessage != null ? lastMessage.getGroupMessageId() : 0L;
@@ -255,7 +261,8 @@ public class GroupChatService extends CommonChatService {
     // ===== DM방 진입 시, 대화 이력 조회 + 안 읽었던 것들 읽음 처리(실시간+비실시간) =====
     // 대화 이력 조회 후 읽지 않은 메시지 읽음 처리
     @Transactional
-    public List<GroupMessageResponse> getGroupMessagesByGroupChatRoomId(Long groupChatroomId, Long cursorId, Integer pageSize, Long userId) {
+    public List<GroupMessageResponse> getGroupMessagesByGroupChatRoomId(Long groupChatroomId, Long cursorId,
+                                                                        Integer pageSize, Long userId) {
         try {
             GroupChatRoom groupChatRoom = getChatRoomById(groupChatroomId);
             User user = getUserById(userId);
@@ -323,7 +330,8 @@ public class GroupChatService extends CommonChatService {
 
     // ===== 그룹 메시지 전송 =====
     @Transactional
-    public GroupMessageResponse processGroupMessage(Long groupChatroomId, GroupMessageSendRequest request, Long userId) {
+    public GroupMessageResponse processGroupMessage(Long groupChatroomId, GroupMessageSendRequest request,
+                                                    Long userId) {
         try {
             GroupChatRoom groupChatRoom = getChatRoomById(groupChatroomId);
             User sender = getUserById(userId);
@@ -401,6 +409,8 @@ public class GroupChatService extends CommonChatService {
                     (sender, recipient, content) -> FcmSendDto.builder()
                             .title(sender.getNickname() + "님의 그룹 메시지")
                             .body(content)
+                            .type("group")
+                            .id(groupChatroomId)
                             .token(recipient.getFcmToken())
                             .build(),
                     fcmService::sendMessage

--- a/src/main/java/org/glue/glue_be/util/fcm/controller/FcmController.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/controller/FcmController.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.glue.glue_be.common.response.BaseResponse;
 import org.glue.glue_be.util.fcm.dto.FcmSendDto;
 import org.glue.glue_be.util.fcm.dto.MultiFcmSendDto;
-import org.glue.glue_be.util.fcm.response.FcmResponseStatus;
 import org.glue.glue_be.util.fcm.service.FcmService;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/org/glue/glue_be/util/fcm/dto/FcmSendDto.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/dto/FcmSendDto.java
@@ -6,15 +6,20 @@ import lombok.*;
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FcmSendDto {
-        private String token;
-        private String title;
-        private String body;
+    private String token;
+    private String title;
+    private String body;
+    private String type;           // 알림 타입 guestbook, post, notice, dm, group 중 하나
+    private Long id;               // targetId
+    private Long guestbookHostId;  // guestbook 타입일 때만 사용
 
-        @Builder(toBuilder = true)
-        public FcmSendDto(String token, String title, String body) {
-                this.token = token;
-                this.title = title;
-                this.body = body;
-        }
+    @Builder(toBuilder = true)
+    public FcmSendDto(String token, String title, String body, String type, Long id, Long guestbookHostId) {
+        this.token = token;
+        this.title = title;
+        this.body = body;
+        this.type = type;
+        this.id = id;
+        this.guestbookHostId = guestbookHostId;
+    }
 }
-

--- a/src/main/java/org/glue/glue_be/util/fcm/dto/MultiFcmSendDto.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/dto/MultiFcmSendDto.java
@@ -10,11 +10,17 @@ public class MultiFcmSendDto {
     private List<String> tokens;
     private String title;
     private String body;
+    private String type;
+    private Long id;
+    private Long guestbookHostId;  // guestbook 타입일 때만 사용
 
     @Builder(toBuilder = true)
-    public MultiFcmSendDto(List<String> tokens, String title, String body) {
+    public MultiFcmSendDto(List<String> tokens, String title, String body, String type, Long id, Long guestbookHostId) {
         this.tokens = tokens;
         this.title = title;
         this.body = body;
+        this.type = type;
+        this.id = id;
+        this.guestbookHostId = guestbookHostId;
     }
 }

--- a/src/main/java/org/glue/glue_be/util/fcm/service/FcmService.java
+++ b/src/main/java/org/glue/glue_be/util/fcm/service/FcmService.java
@@ -1,34 +1,48 @@
 package org.glue.glue_be.util.fcm.service;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.MulticastMessage;
-import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.*;
 import lombok.extern.slf4j.Slf4j;
 import org.glue.glue_be.common.exception.BaseException;
-import org.glue.glue_be.util.fcm.dto.FcmSendDto;
-import org.glue.glue_be.util.fcm.dto.MultiFcmSendDto;
+import org.glue.glue_be.util.fcm.dto.*;
 import org.glue.glue_be.util.fcm.response.FcmResponseStatus;
 import org.springframework.stereotype.Service;
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @Slf4j
 public class FcmService {
 
-    // TODO: 개발 완료 후, 예외를 던지지 않도록 수정 예정
     public void sendMessage(FcmSendDto fcmSendDto) {
         if (fcmSendDto.getToken() == null || fcmSendDto.getToken().isBlank()) {
             log.error("[FCM 단일 전송 실패] 유효하지 않은 토큰: null 또는 빈 값");
             throw new BaseException(FcmResponseStatus.FCM_SEND_ERROR, "FCM 토큰이 비어있습니다.");
         }
 
+        if (fcmSendDto.getType() == null || fcmSendDto.getType().isBlank()) {
+            log.error("[FCM 단일 전송 실패] 알림 타입이 누락되었습니다.");
+            throw new BaseException(FcmResponseStatus.FCM_SEND_ERROR, "FCM 알림 type은 필수입니다.");
+        }
+
+        if (fcmSendDto.getId() == null) {
+            log.error("[FCM 단일 전송 실패] 알림 대상 ID가 누락되었습니다.");
+            throw new BaseException(FcmResponseStatus.FCM_SEND_ERROR, "FCM 알림 id는 필수입니다.");
+        }
+
+        Map<String, String> data = new HashMap<>();
+        data.put("type", fcmSendDto.getType());
+        data.put("id", fcmSendDto.getId().toString());
+
+        if (fcmSendDto.getGuestbookHostId() != null) {
+            data.put("guestbookHostId", fcmSendDto.getGuestbookHostId().toString());
+        }
 
         Message message = Message.builder()
                 .setNotification(Notification.builder()
                         .setTitle(fcmSendDto.getTitle())
                         .setBody(fcmSendDto.getBody())
                         .build())
+                .putAllData(data)
                 .setToken(fcmSendDto.getToken())
                 .build();
 
@@ -55,6 +69,9 @@ public class FcmService {
                     .token(token)
                     .title(multiFcmSendDto.getTitle())
                     .body(multiFcmSendDto.getBody())
+                    .type(multiFcmSendDto.getType())
+                    .id(multiFcmSendDto.getId())
+                    .guestbookHostId(multiFcmSendDto.getGuestbookHostId())
                     .build();
 
             try {
@@ -72,6 +89,4 @@ public class FcmService {
             throw new BaseException(FcmResponseStatus.FCM_MULTICAST_ERROR, "일부 FCM 전송에 실패했습니다.");
         }
     }
-
-
 }


### PR DESCRIPTION
### 주요 변경 사항
- FcmSendDto, MultiFcmSendDto에 `type`, `id`, `guestbookHostId` 필드 추가
- FcmService에서 해당 필드 전송 및 유효성 검증 처리
- NotificationService에서 알림 생성 시 필드 포함 전송
- broadcastMessage()에서 DM 전송 시 `type: dm`, `id: chatroomId` 포함