### PR TITLE
feat: 채팅 리스트에 실시간 기능 도입

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/entity/group/GroupChatRoom.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/group/GroupChatRoom.java
@@ -37,4 +37,8 @@ public class GroupChatRoom extends BaseEntity {
     public void updateMeeting(Meeting meeting) {
         this.meeting = meeting;
     }
+
+    public void updateLastActivity() {
+        this.touchUpdatedAt();
+    }
 }

--- a/src/main/java/org/glue/glue_be/chat/event/ChatRoomListUpdateDto.java
+++ b/src/main/java/org/glue/glue_be/chat/event/ChatRoomListUpdateDto.java
@@ -1,0 +1,44 @@
+package org.glue.glue_be.chat.event;
+
+import org.glue.glue_be.chat.dto.response.DmChatRoomListResponse;
+import org.glue.glue_be.chat.dto.response.GroupChatRoomListResponse;
+import org.glue.glue_be.common.dto.MeetingSummary;
+import org.glue.glue_be.common.dto.UserSummary;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomListUpdateDto(
+        Long chatRoomId,
+        String chatRoomType,           // "DM" 또는 "MEETING"
+        UserSummary otherUser,         // DM 상대방 정보 (모임톡인 경우 null)
+        MeetingSummary meeting,        // 모임톡 정보 (DM인 경우 null)
+        String lastMessage,
+        LocalDateTime lastMessageTime,
+        boolean hasUnreadMessages
+) {
+    // DM 채팅방용 정적 팩토리 메서드
+    public static ChatRoomListUpdateDto fromDm(DmChatRoomListResponse response, LocalDateTime messageTime) {
+        return new ChatRoomListUpdateDto(
+                response.getDmChatRoomId(),
+                "DM",
+                response.getOtherUser(),
+                null, // DM은 모임 정보 필요 없음
+                response.getLastMessage(),
+                messageTime,
+                response.isHasUnreadMessages()
+        );
+    }
+
+    // 모임톡용 정적 팩토리 메서드
+    public static ChatRoomListUpdateDto fromGroup(GroupChatRoomListResponse response, LocalDateTime messageTime) {
+        return new ChatRoomListUpdateDto(
+                response.groupChatroomId(),
+                "GROUP",
+                null, // 모임톡은 상대방 정보 필요 없음
+                response.meeting(),
+                response.lastMessage(),
+                messageTime,
+                response.hasUnreadMessages()
+        );
+    }
+}

--- a/src/main/java/org/glue/glue_be/chat/event/ChatRoomListUpdateHandler.java
+++ b/src/main/java/org/glue/glue_be/chat/event/ChatRoomListUpdateHandler.java
@@ -1,0 +1,183 @@
+package org.glue.glue_be.chat.event;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.glue.glue_be.chat.dto.response.DmChatRoomListResponse;
+import org.glue.glue_be.chat.dto.response.GroupChatRoomListResponse;
+import org.glue.glue_be.chat.entity.dm.DmMessage;
+import org.glue.glue_be.chat.entity.dm.DmUserChatroom;
+import org.glue.glue_be.chat.entity.group.GroupChatRoom;
+import org.glue.glue_be.chat.entity.group.GroupMessage;
+import org.glue.glue_be.chat.entity.group.GroupUserChatRoom;
+import org.glue.glue_be.chat.repository.dm.DmMessageRepository;
+import org.glue.glue_be.chat.repository.dm.DmUserChatroomRepository;
+import org.glue.glue_be.chat.repository.group.GroupChatRoomRepository;
+import org.glue.glue_be.chat.repository.group.GroupMessageRepository;
+import org.glue.glue_be.chat.repository.group.GroupUserChatRoomRepository;
+import org.glue.glue_be.common.dto.MeetingSummary;
+import org.glue.glue_be.user.entity.User;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.glue.glue_be.common.dto.UserSummary;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChatRoomListUpdateHandler {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    // DM 관련
+    private final DmUserChatroomRepository dmUserChatroomRepository;
+    private final DmMessageRepository dmMessageRepository;
+
+    // 그룹 관련
+    private final GroupUserChatRoomRepository groupUserChatroomRepository;
+    private final GroupMessageRepository groupMessageRepository;
+    private final GroupChatRoomRepository groupChatRoomRepository;
+
+    @EventListener
+    @Transactional
+    public void handleNewMessage(MessageCreatedEvent event) {
+        switch (event.type()) {
+            case "DM" -> updateDmChatRoomList(event.chatRoomId(), event.senderId(), event.createdAt());
+            case "GROUP" -> updateGroupChatRoomList(event.chatRoomId(), event.senderId(), event.createdAt());
+            default -> log.warn("알 수 없는 채팅 타입: {}", event.type());
+        }
+    }
+
+    @EventListener
+    @Transactional
+    public void handleMessageRead(MessageReadEvent event) {
+        switch (event.chatRoomType()) {
+            case "DM" -> updateDmChatRoomList(event.chatRoomId(), event.userId(), null);
+            case "GROUP" -> updateGroupChatRoomList(event.chatRoomId(), event.userId(), null);
+            default -> log.warn("알 수 없는 채팅 타입: {}", event.chatRoomType());
+        }
+    }
+
+    private void updateDmChatRoomList(Long chatRoomId, Long targetUserId, LocalDateTime updateTime) {
+        // DM 채팅방의 모든 참가자들 조회
+        List<DmUserChatroom> participants = dmUserChatroomRepository.findByDmChatRoom_Id(chatRoomId);
+
+        // 모든 참가자에게 알림 전송 (읽음 처리한 사용자 포함)
+        participants.forEach(participant -> {
+            User receiver = participant.getUser();
+
+            // 수신자 관점에서의 DM 채팅방 정보 생성 (읽음 상태 자동 계산됨)
+            DmChatRoomListResponse updatedChatRoom = createDmChatRoomResponse(
+                    chatRoomId, receiver);
+
+            // WebSocket으로 수신자에게 전송
+            ChatRoomListUpdateDto updateDto = ChatRoomListUpdateDto.fromDm(
+                    updatedChatRoom,
+                    LocalDateTime.now() // 읽음 처리 시간
+            );
+
+            messagingTemplate.convertAndSendToUser(
+                    receiver.getUserId().toString(),
+                    "/queue/chatroom-list-update",
+                    updateDto
+            );
+
+            log.debug("DM 읽음 처리 업데이트 알림 전송: receiverId={}, chatRoomId={}, targetUserId={}",
+                    receiver.getUserId(), chatRoomId, targetUserId);
+        });
+    }
+
+    private void updateGroupChatRoomList(Long chatRoomId, Long otherUserId, LocalDateTime updateTime) {
+//        // 그룹 채팅방의 모든 참가자들 조회
+//        List<GroupUserChatRoom> participants = groupUserChatroomRepository.findByGroupChatRoomId(chatRoomId);
+//
+//        // 제외할 사용자를 제외한 모든 참가자에게 알림
+//        participants.stream()
+//                .filter(participant -> !participant.getUser().getUserId().equals(otherUserId))
+//                .forEach(participant -> {
+//                    User receiver = participant.getUser();
+//
+//                    // 수신자 관점에서의 그룹 채팅방 정보 생성
+//                    GroupChatRoomListResponse updatedChatRoom = createGroupChatRoomResponse(
+//                            chatRoomId, receiver);
+//
+//                    // WebSocket으로 수신자에게 전송
+//                    ChatRoomListUpdateDto updateDto = ChatRoomListUpdateDto.fromMeeting(
+//                            updatedChatRoom,
+//                            updateTime
+//                    );
+//
+//                    messagingTemplate.convertAndSendToUser(
+//                            receiver.getUserId().toString(),
+//                            "/queue/chatroom-list-update",
+//                            updateDto
+//                    );
+//
+//                    log.debug("그룹 채팅방 목록 업데이트 알림 전송: receiverId={}, chatRoomId={}, otherUserId={}",
+//                            receiver.getUserId(), chatRoomId, otherUserId);
+//                });
+    }
+
+    // DM 채팅방 정보 생성
+    private DmChatRoomListResponse createDmChatRoomResponse(Long chatRoomId, User currentUser) {
+        List<DmUserChatroom> participants = dmUserChatroomRepository.findByDmChatRoom_Id(chatRoomId);
+
+        User otherUser = participants.stream()
+                .map(DmUserChatroom::getUser)
+                .filter(user -> !user.getUserId().equals(currentUser.getUserId()))
+                .findFirst()
+                .orElse(currentUser);
+
+        DmMessage lastMessage = dmMessageRepository.findTopByDmChatRoomIdOrderByCreatedAtDesc(chatRoomId)
+                .orElse(null);
+
+        // 안읽은 메시지 여부 확인
+        Long currentUserLastReadMessageId = getCurrentUserLastReadMessageId(currentUser.getUserId(), chatRoomId);
+        long latestMessageId = getLatestMessageId(chatRoomId);
+        boolean hasUnreadMessages = currentUserLastReadMessageId < latestMessageId;
+
+        // UserSummary 생성
+        UserSummary otherUserSummary = new UserSummary(
+                otherUser.getUserId(),
+                otherUser.getNickname(),
+                otherUser.getProfileImageUrl()
+        );
+
+        return DmChatRoomListResponse.builder()
+                .dmChatRoomId(chatRoomId)
+                .meetingId(null) // DM은 모임 ID 없음
+                .otherUser(otherUserSummary)
+                .lastMessage(lastMessage != null ? lastMessage.getDmMessageContent() : null)
+                .lastMessageTime(lastMessage != null ? lastMessage.getCreatedAt() : null)
+                .hasUnreadMessages(hasUnreadMessages)
+                .build();
+    }
+
+    private Long getCurrentUserLastReadMessageId(Long userId, Long chatRoomId) {
+        return dmUserChatroomRepository.findByUser_UserIdAndDmChatRoom_Id(userId, chatRoomId)
+                .map(DmUserChatroom::getLastReadMessageId)
+                .orElse(0L);
+    }
+
+    private long getLatestMessageId(Long chatRoomId) {
+        return dmMessageRepository.findTopByDmChatRoomIdOrderByCreatedAtDesc(chatRoomId)
+                .map(DmMessage::getId)
+                .orElse(0L);
+    }
+
+//    private Long getCurrentUserLastReadMessageIdForGroup(Long userId, Long chatRoomId) {
+//        return groupUserChatroomRepository.findByUserUserIdAndGroupChatRoomId(userId, chatRoomId)
+//                .map(GroupUserChatRoom::getLastReadMessageId)
+//                .orElse(0L);
+//    }
+//
+//    private long getLatestMessageIdForGroup(Long chatRoomId) {
+//        return groupMessageRepository.findTopByGroupChatRoomIdOrderByCreatedAtDesc(chatRoomId)
+//                .map(GroupMessage::getId)
+//                .orElse(0L);
+//    }
+}

--- a/src/main/java/org/glue/glue_be/chat/event/MessageCreatedEvent.java
+++ b/src/main/java/org/glue/glue_be/chat/event/MessageCreatedEvent.java
@@ -1,0 +1,13 @@
+package org.glue.glue_be.chat.event;
+
+import java.time.LocalDateTime;
+
+public record MessageCreatedEvent(
+        Long messageId,
+        Long chatRoomId,
+        Long senderId,
+        String content,
+        LocalDateTime createdAt,
+        String type
+) {
+}

--- a/src/main/java/org/glue/glue_be/chat/event/MessageReadEvent.java
+++ b/src/main/java/org/glue/glue_be/chat/event/MessageReadEvent.java
@@ -1,0 +1,8 @@
+package org.glue.glue_be.chat.event;
+
+public record MessageReadEvent(
+        Long userId,           // 읽음 처리한 사용자 ID
+        Long chatRoomId,       // 채팅방 ID
+        String chatRoomType    // "DM" 또는 "GROUP"
+) {
+}

--- a/src/main/java/org/glue/glue_be/chat/repository/dm/DmMessageRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/dm/DmMessageRepository.java
@@ -18,6 +18,8 @@ public interface DmMessageRepository extends JpaRepository<DmMessage, Long> {
 
     Optional<DmMessage> findTopByDmChatRoomOrderByCreatedAtDesc(DmChatRoom chatRoom);
 
+    Optional<DmMessage> findTopByDmChatRoomIdOrderByCreatedAtDesc(Long dmChatRoomId);
+
     // 커서 기반 메시지 조회를 위한 새로운 메서드들 (id 필드 사용)
     // 첫 번째 요청 (cursorId가 null일 때) - 최신 메시지부터 내림차순
     List<DmMessage> findByDmChatRoomOrderByIdDesc(DmChatRoom dmChatRoom, Pageable pageable);

--- a/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/dm/DmUserChatroomRepository.java
@@ -17,6 +17,8 @@ import java.util.Optional;
 public interface DmUserChatroomRepository extends JpaRepository<DmUserChatroom, Long> {
     List<DmUserChatroom> findByDmChatRoom(DmChatRoom dmChatRoom);
 
+    List<DmUserChatroom> findByDmChatRoom_Id(Long Id);
+
     void deleteByDmChatRoomAndUser(DmChatRoom dmChatRoom, User user);
 
     Optional<DmUserChatroom> findByDmChatRoomAndUser(DmChatRoom dmChatRoom, User sender);

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupChatRoomRepository.java
@@ -24,15 +24,15 @@ public interface GroupChatRoomRepository extends JpaRepository<GroupChatRoom, Lo
     @Query("SELECT DISTINCT gc FROM GroupChatRoom gc " +
             "JOIN gc.groupUserChatrooms guc " +
             "WHERE guc.user = :user " +
-            "ORDER BY gc.groupChatroomId DESC")
-    List<GroupChatRoom> findByUserOrderByGroupChatroomIdDesc(@Param("user") User user, Pageable pageable);
+            "ORDER BY gc.updatedAt DESC")
+    List<GroupChatRoom> findByUserOrderByGroupChatroomUpdatedAtDesc(@Param("user") User user, Pageable pageable);
 
     @Query("SELECT DISTINCT gc FROM GroupChatRoom gc " +
             "JOIN gc.groupUserChatrooms guc " +
             "WHERE guc.user = :user " +
             "AND gc.groupChatroomId < :cursorId " +
-            "ORDER BY gc.groupChatroomId DESC")
-    List<GroupChatRoom> findByUserAndGroupChatroomIdLessThanOrderByGroupChatroomIdDesc(
+            "ORDER BY gc.updatedAt DESC")
+    List<GroupChatRoom> findByUserAndGroupChatroomUpdatedAtLessThanOrderByGroupChatroomIdDesc(
             @Param("user") User user,
             @Param("cursorId") Long cursorId,
             Pageable pageable);

--- a/src/main/java/org/glue/glue_be/chat/repository/group/GroupUserChatRoomRepository.java
+++ b/src/main/java/org/glue/glue_be/chat/repository/group/GroupUserChatRoomRepository.java
@@ -1,5 +1,6 @@
 package org.glue.glue_be.chat.repository.group;
 
+import org.glue.glue_be.chat.entity.dm.DmUserChatroom;
 import org.glue.glue_be.chat.entity.group.GroupChatRoom;
 import org.glue.glue_be.chat.entity.group.GroupUserChatRoom;
 import org.glue.glue_be.user.entity.User;
@@ -18,6 +19,8 @@ public interface GroupUserChatRoomRepository extends JpaRepository<GroupUserChat
 
     // 채팅방의 모든 참여자 조회
     List<GroupUserChatRoom> findByGroupChatroom(GroupChatRoom groupChatroom);
+
+    List<GroupUserChatRoom> findByGroupChatroom_GroupChatroomId(Long Id);
 
     // 채팅방과 유저로 삭제
     void deleteByGroupChatroomAndUser(GroupChatRoom groupChatroom, User user);

--- a/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/DmChatService.java
@@ -380,16 +380,13 @@ public class DmChatService extends CommonChatService {
                     dmUserChatroomRepository::updateLastReadMessageId
             );
 
-            publishReadEvent(userId, dmChatRoomId);
+            eventPublisher.publishEvent(new MessageReadEvent(userId, dmChatRoomId, "DM"));
+
         } catch (BaseException e) {
             throw e;
         } catch (Exception e) {
             throw new BaseException(ChatResponseStatus.MESSAGES_READ_FAILED);
         }
-    }
-
-    private void publishReadEvent(Long userId, Long dmChatRoomId) {
-        eventPublisher.publishEvent(new MessageReadEvent(userId, dmChatRoomId, "DM"));
     }
 
     // 메시지 읽음 알림 전송(푸시 알림 아님, 실시간 알림)

--- a/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
@@ -179,8 +179,8 @@ public class GroupChatService extends CommonChatService {
                     pageSize,
                     userId,
                     this::getUserById,
-                    groupChatRoomRepository::findByUserOrderByGroupChatroomIdDesc,
-                    groupChatRoomRepository::findByUserAndGroupChatroomIdLessThanOrderByGroupChatroomIdDesc,
+                    groupChatRoomRepository::findByUserOrderByGroupChatroomUpdatedAtDesc,
+                    groupChatRoomRepository::findByUserAndGroupChatroomUpdatedAtLessThanOrderByGroupChatroomIdDesc,
                     this::convertToGroupChatRoomResponses
             );
         } catch (BaseException e) {
@@ -356,6 +356,8 @@ public class GroupChatService extends CommonChatService {
             );
 
             GroupMessage savedMessage = groupMessageRepository.save(message);
+            chatRoom.updateLastActivity();
+
             return responseMapper.toMessageResponse(savedMessage);
         } catch (Exception e) {
             throw new BaseException(ChatResponseStatus.MESSAGE_SENDING_FAILED);

--- a/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
@@ -404,13 +404,7 @@ public class GroupChatService extends CommonChatService {
             // 모든 참여자에게 웹소켓 전송
             // 웹소켓에 연결된 사용자만 실제 수신
             // 오프라인 수신자는 받지도 않고 에러를 내지도 않고 그냥 무시
-            for (UserSummary participant : chatRoom.participants()) {
-                Long participantId = participant.getUserId();
-
-                if (!participantId.equals(senderId)) {
-                    messagingTemplate.convertAndSend("/topic/group/" + participantId, messageResponse);
-                }
-            }
+            messagingTemplate.convertAndSend("/topic/group/" + groupChatroomId, messageResponse);
 
             // 모든 오프라인 참여자에게 푸시 알림 전송
             sendPushNotificationsToOfflineReceivers(


### PR DESCRIPTION
## 개요
간과하고 있었는데, 생각해보니 채팅 리스트도 실시간으로 메시지가 오는 걸 감지하여 마지막 메시지 변경, 안읽음 상태 변경, 채팅 리스트 렌더링이 필요할 것 같아서 실시간 기능 도입했습니다.

## 설명
- 기술적인 설명은 코멘트로 달겠습니다.

### 0. 사전작업: 채팅방 리스트 updatedAt 기준으로 정렬
- 기존에는, 채팅방 정보가 직접적으로 수정될 일이 없어서 auto increment되는 id를 기준으로 정렬되도록 했습니다.
- 그런데, 마지막 메시지가 언제 왔는지를 기준으로 하여 채팅방을 정렬해야 할 것 같아서, 메시지를 수신할 때마다 채팅방의 updatedAt이 바뀌도록 하고, 이를 기준으로 데이터가 정렬되도록 했습니다.

### 1. 웹소켓 적용
- 쪽지과 그룹 모두 `/user/queue/chatroom-list-update` 를 사용하여 채팅방 리스트 상태를 구독하도록 했습니다.
- 쪽지의 경우, ui상 채팅방 리스트에 "마지막 메시지, 읽음 상태" 외에도 "대화 상대 프로필 사진, 닉네임"이 있었는데, 후자는 실시간을 적용하지 않고, 유저가 새로고침을 요청했을 때 바뀌는 게 리소스적으로나 흐름적으로나 자연스럽다고 판단하여, 전자에만 실시간 업데이트를 적용했습니다.
- 그룹의 경우도, 쪽지와 마찬가지로, "마지막 메시지, 읽음 상태"에만 실시간 업데이트를 적용하고, 이외에 "미팅 사진, 미팅 이름, 미팅 인원 수"에는 실시간을 적용하지 않았습니다.

## 발견됐던 버그 (기록용 + 참고용) (좀 재밌음)
### 1. JPA 1차 캐싱
1. 원래 상황 (버그 있을 때)
```
1. markMessagesAsRead() 실행
   └─ updateLastReadMessageId() 실행 (DB 업데이트)
   └─ 트랜잭션 커밋
   
2. handleMessageRead() 실행 (새 트랜잭션)
   └─ getCurrentUserLastReadMessageId() 호출
   └─ JPA: "어? 이 데이터 이미 메모리에 있네!" 
   └─ 예전 값 반환 (DB 안 보고!)
```
2. 해결 후 상황
```
1. markMessagesAsRead() 실행 + 커밋

2. handleMessageRead() 실행
   └─ entityManager.clear() ← "메모리 캐시 다 지워!"
   └─ getCurrentUserLastReadMessageId() 호출
   └─ JPA: "메모리에 없네, DB에서 가져와야지"
   └─ 최신 값 반환! ✅
```
3. 왜 이런 일이?
- JPA는 성능을 위해 한번 조회한 엔티티를 메모리에 캐시해둔다고 합니다.
- DmUserChatroom 엔티티를 한 번 조회하면 메모리에 저장
- 같은 ID로 다시 조회할 때는 DB 안 가고 메모리에서 가져옴
- 심지어 다른 트랜잭션에서도!,,,,,,

4. 언제 이런 문제가 생기나?
- 같은 엔티티를 여러 번 조회할 때
- 트랜잭션이 달라도 같은 영속성 컨텍스트를 사용할 때
- Update 후 바로 Select할 때

### 2. 구독 전송 방식
1. 기존의 문제: 그룹에서 `/topic/chatroom-list-update/{chatroomId}` 사용 시도
```
ChatRoomListUpdateDto updateDto = createChatRoomUpdateDto(chatRoomId, representativeUser, chatRoomType);
messagingTemplate.convertAndSend("/topic/chatroom-list-update/" + chatRoomId, updateDto);
```
- 모든 사용자가 동일한 hasUnreadMessages 값을 받음
- 대표 사용자 기준으로 DTO 생성하여 다른 사용자들의 실제 읽음 상태와 불일치
- 개인화된 정보가 정확히 반영되지 않음

2. 해결: DM과 그룹 모두 `/user/queue/chatroom-list-update` 사용
- 자세한 건 노션의 "WebSocket에서 /topic vs /queue 선택 기준" 문서 읽어보시면 나와있습니다.

close #119 