### PR TITLE
feat: 그룹 채팅 입장/퇴장 시 실시간 처리 + 메시지 전달

### DIFF
--- a/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
@@ -63,9 +63,9 @@ public class GroupChatController {
     // 그룹 채팅방 나가기
     @DeleteMapping("/rooms/{groupChatroomId}/leave")
     @Operation(summary = "채팅방 나가기")
-    public ResponseEntity<List<ActionResponse>> leaveChatRoom(@PathVariable Long groupChatroomId,
+    public ResponseEntity<GroupChatRoomLeaveResult> leaveChatRoom(@PathVariable Long groupChatroomId,
                                                               @AuthenticationPrincipal CustomUserDetails auth) {
-        List<ActionResponse> response = groupChatService.leaveGroupChatRoom(groupChatroomId, auth.getUserId());
+        GroupChatRoomLeaveResult response = groupChatService.leaveGroupChatRoom(groupChatroomId, auth.getUserId());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
@@ -90,7 +90,7 @@ public class GroupChatController {
             @RequestBody GroupMessageSendRequest request,
             @AuthenticationPrincipal CustomUserDetails auth) {
         GroupMessageResponse response = groupChatService.processGroupMessage(groupChatroomId, request,
-                auth.getUserId());
+                auth.getUserId(), null);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
+++ b/src/main/java/org/glue/glue_be/chat/controller/GroupChatController.java
@@ -21,9 +21,15 @@ public class GroupChatController {
 
     private final GroupChatService groupChatService;
 
-    // 그룹 채팅방 침야
+    // 그룹 채팅방 참여
     @GetMapping("/rooms/create/{meetingId}")
-    @Operation(summary = "그룹 채팅방 참여")
+    @Operation(summary = "그룹 채팅방 참여",
+            description = """
+        **응답 설명:**
+        - 호스트가 아닌 사람의 신규 참여 시에만 포함됩니다.
+        - joinMessage.code: 항상 2
+        - joinMessage.message: @@@ 님이 참여했습니다
+        """)
     public ResponseEntity<GroupChatRoomCreateResult> createGroupChatRoom(@PathVariable Long meetingId,
                                                                          @AuthenticationPrincipal CustomUserDetails auth) {
         GroupChatRoomCreateResult result = groupChatService.createGroupChatRoom(meetingId, auth.getUserId());
@@ -62,7 +68,12 @@ public class GroupChatController {
 
     // 그룹 채팅방 나가기
     @DeleteMapping("/rooms/{groupChatroomId}/leave")
-    @Operation(summary = "채팅방 나가기")
+    @Operation(summary = "채팅방 나가기",
+            description = """
+        **응답 설명:**
+        - leaveMessage.code: 항상 3
+        - leaveMessage.message: @@@ 님이 나갔습니다
+        """)
     public ResponseEntity<GroupChatRoomLeaveResult> leaveChatRoom(@PathVariable Long groupChatroomId,
                                                               @AuthenticationPrincipal CustomUserDetails auth) {
         GroupChatRoomLeaveResult response = groupChatService.leaveGroupChatRoom(groupChatroomId, auth.getUserId());

--- a/src/main/java/org/glue/glue_be/chat/dto/response/ChatResponseStatus.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/ChatResponseStatus.java
@@ -27,7 +27,9 @@ public enum ChatResponseStatus implements ResponseStatus {
     MESSAGE_SENDING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "메시지 전송에 실패하였습니다"),
     MESSAGES_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, false, 500, "메시지 읽음 처리 실패하였습니다"),
     INVITATION_STATUS_ERROR(HttpStatus.BAD_REQUEST, false, 400, "초대 상태를 확인할 수 없습니다"),
-    RECIPIENT_USER_DELETED(HttpStatus.FORBIDDEN, false, 403, "탈퇴한 사용자와는 메시지를 주고받을 수 없습니다");
+    RECIPIENT_USER_DELETED(HttpStatus.FORBIDDEN, false, 403, "탈퇴한 사용자와는 메시지를 주고받을 수 없습니다"),
+    MESSAGE_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, false, 400, "메시지 내용이 필요합니다.");
+
 
     private final HttpStatusCode httpStatusCode;
     private final boolean success;

--- a/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomCreateResult.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomCreateResult.java
@@ -1,6 +1,10 @@
 package org.glue.glue_be.chat.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record GroupChatRoomCreateResult(
         GroupChatRoomDetailResponse chatroom,
-        ActionResponse status
+        ActionResponse status,
+        ActionResponse joinLeaveMessage
 ) {}

--- a/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomCreateResult.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomCreateResult.java
@@ -6,5 +6,5 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public record GroupChatRoomCreateResult(
         GroupChatRoomDetailResponse chatroom,
         ActionResponse status,
-        ActionResponse joinLeaveMessage
+        ActionResponse joinMessage
 ) {}

--- a/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomLeaveResult.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomLeaveResult.java
@@ -1,7 +1,10 @@
 package org.glue.glue_be.chat.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record GroupChatRoomLeaveResult(
         List<ActionResponse> status,
         ActionResponse leaveMessage

--- a/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomLeaveResult.java
+++ b/src/main/java/org/glue/glue_be/chat/dto/response/GroupChatRoomLeaveResult.java
@@ -1,0 +1,8 @@
+package org.glue.glue_be.chat.dto.response;
+
+import java.util.List;
+
+public record GroupChatRoomLeaveResult(
+        List<ActionResponse> status,
+        ActionResponse leaveMessage
+) {}

--- a/src/main/java/org/glue/glue_be/chat/entity/group/GroupMessage.java
+++ b/src/main/java/org/glue/glue_be/chat/entity/group/GroupMessage.java
@@ -17,6 +17,10 @@ public class GroupMessage extends BaseEntity {
 
     public static final int UNREAD_COUNT_DEFAULT = 1;
 
+    public static final int TEXT = 1;
+    public static final int JOIN = 2;
+    public static final int LEAVE = 3;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long groupMessageId;
@@ -36,12 +40,16 @@ public class GroupMessage extends BaseEntity {
     @Column(name = "message_content")
     private String message;
 
+    @Column(name = "message_type", nullable = false)
+    private Integer messageType = TEXT;
+
     // Constructor with required fields
-    public GroupMessage(User user, GroupChatRoom groupChatroom, Meeting meeting, String message) {
+    public GroupMessage(User user, GroupChatRoom groupChatroom, Meeting meeting, String message, Integer messageType) {
         this.user = user;
         this.groupChatroom = groupChatroom;
         this.meeting = meeting;
         this.message = message;
+        this.messageType = messageType;
     }
 
 }

--- a/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
@@ -238,7 +238,7 @@ public class GroupChatService extends CommonChatService {
 
     // ===== 그룹 채팅방 나가기 =====
     @Transactional
-    public List<ActionResponse> leaveGroupChatRoom(Long groupChatroomId, Long userId) {
+    public GroupChatRoomLeaveResult leaveGroupChatRoom(Long groupChatroomId, Long userId) {
         try {
             GroupChatRoom chatRoom = getChatRoomById(groupChatroomId);
             User user = getUserById(userId);
@@ -249,9 +249,9 @@ public class GroupChatService extends CommonChatService {
                 throw new BaseException(ChatResponseStatus.HOST_CANNOT_LEAVE);
             }
 
-            processGroupMessage(groupChatroomId, null, userId, GroupMessage.LEAVE);
+            GroupMessageResponse groupMessageResponse = processGroupMessage(groupChatroomId, null, userId, GroupMessage.LEAVE);
 
-            return (List<ActionResponse>) processLeaveChatRoom(
+            List<ActionResponse> leaveResults = processLeaveChatRoom(
                     groupChatroomId,
                     userId,
                     this::getChatRoomById,
@@ -263,6 +263,11 @@ public class GroupChatService extends CommonChatService {
                     groupMessageRepository::deleteAll,
                     groupChatRoomRepository::delete
             );
+
+            ActionResponse systemMessage = new ActionResponse(GroupMessage.LEAVE, groupMessageResponse.message());
+
+            return new GroupChatRoomLeaveResult(leaveResults, systemMessage);
+
         } catch (BaseException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
+++ b/src/main/java/org/glue/glue_be/chat/service/GroupChatService.java
@@ -70,17 +70,22 @@ public class GroupChatService extends CommonChatService {
                     return new GroupChatRoomCreateResult(
                             getGroupChatRoomDetail(chatRoom.getGroupChatroomId(), userId),
                             new ActionResponse(ChatResponseStatus.CHATROOM_JOINED.getCode(),
-                                    ChatResponseStatus.CHATROOM_JOINED.getMessage())
+                                    ChatResponseStatus.CHATROOM_JOINED.getMessage()),
+                            null
                     );
                 } else {
                     // 채팅방에 사용자 추가
                     GroupUserChatRoom groupUserChatRoom = new GroupUserChatRoom(user, chatRoom);
                     groupUserChatRoomRepository.save(groupUserChatRoom);
 
+                    GroupMessageResponse groupMessageResponse = processGroupMessage(chatRoom.getGroupChatroomId(), null, userId, GroupMessage.JOIN);
+
                     return new GroupChatRoomCreateResult(
                             getGroupChatRoomDetail(chatRoom.getGroupChatroomId(), userId),
                             new ActionResponse(ChatResponseStatus.CHATROOM_JOINED.getCode(),
-                                    ChatResponseStatus.CHATROOM_JOINED.getMessage())
+                                    ChatResponseStatus.CHATROOM_JOINED.getMessage()),
+                            new ActionResponse(GroupMessage.JOIN,
+                                    groupMessageResponse.message())
                     );
                 }
             } else {
@@ -100,7 +105,8 @@ public class GroupChatService extends CommonChatService {
                 return new GroupChatRoomCreateResult(
                         getGroupChatRoomDetail(savedChatRoom.getGroupChatroomId(), userId),
                         new ActionResponse(ChatResponseStatus.CHATROOM_CREATED.getCode(),
-                                ChatResponseStatus.CHATROOM_CREATED.getMessage())
+                                ChatResponseStatus.CHATROOM_CREATED.getMessage()),
+                        null
                 );
             }
         } catch (BaseException e) {
@@ -243,6 +249,8 @@ public class GroupChatService extends CommonChatService {
                 throw new BaseException(ChatResponseStatus.HOST_CANNOT_LEAVE);
             }
 
+            processGroupMessage(groupChatroomId, null, userId, GroupMessage.LEAVE);
+
             return (List<ActionResponse>) processLeaveChatRoom(
                     groupChatroomId,
                     userId,
@@ -340,14 +348,20 @@ public class GroupChatService extends CommonChatService {
     // ===== 그룹 메시지 전송 =====
     @Transactional
     public GroupMessageResponse processGroupMessage(Long groupChatroomId, GroupMessageSendRequest request,
-                                                    Long userId) {
+                                                    Long userId, Integer messageType) {
         try {
             GroupChatRoom groupChatRoom = getChatRoomById(groupChatroomId);
             User sender = getUserById(userId);
             validateChatRoomMember(groupChatRoom, sender);
 
+            if (messageType == null) {
+                messageType = GroupMessage.TEXT;
+            }
+
+            String messageContent = getMessageContent(request, messageType, sender);
+
             // 메시지 db에 저장
-            GroupMessageResponse response = saveGroupMessage(groupChatRoom, sender, request.content());
+            GroupMessageResponse response = saveGroupMessage(groupChatRoom, sender, messageContent, messageType);
 
             // 채팅방 목록 업데이트 이벤트 발행
             publishChatRoomListUpdateEvent(response, groupChatroomId, userId);
@@ -364,15 +378,29 @@ public class GroupChatService extends CommonChatService {
         }
     }
 
+    private String getMessageContent(GroupMessageSendRequest request, Integer messageType, User sender) {
+        if (messageType.equals(GroupMessage.JOIN)) {
+            return sender.getNickname() + " 님이 참여했습니다.";
+        } else if (messageType.equals(GroupMessage.LEAVE)) {
+            return sender.getNickname() + " 님이 나갔습니다.";
+        } else {
+            if (request == null || request.content() == null) {
+                throw new BaseException(ChatResponseStatus.MESSAGE_CONTENT_REQUIRED);
+            }
+            return request.content();
+        }
+    }
+
     // 메시지 db에 저장
-    private GroupMessageResponse saveGroupMessage(GroupChatRoom chatRoom, User sender, String content) {
+    private GroupMessageResponse saveGroupMessage(GroupChatRoom chatRoom, User sender, String content, Integer messageType) {
         try {
             // 메시지 생성 및 저장
             GroupMessage message = new GroupMessage(
                     sender,
                     chatRoom,
                     chatRoom.getMeeting(),
-                    content
+                    content,
+                    messageType
             );
 
             GroupMessage savedMessage = groupMessageRepository.save(message);


### PR DESCRIPTION
## 작업 내용
- 그룹 채팅방 입장/퇴장 시스템 메시지 기능 추가
- 메시지 타입 구분을 위한 `message_type` 컬럼 추가
- 채팅방 참여/나가기 API 응답 구조 개선

## 주요 변경사항

### 1. 데이터베이스 변경
- `group_message` 테이블에 `message_type` 컬럼 추가 (INT, DEFAULT 1)
- 메시지 타입: 1(일반), 2(입장), 3(퇴장)

### 2. 엔티티 수정
```java
// GroupMessage.java
@Column(name = "message_type", nullable = false)
private Integer messageType = TEXT;

public static final int TEXT = 1;
public static final int JOIN = 2;
public static final int LEAVE = 3;
```

### 3. API 응답 구조 개선
- `GroupChatRoomCreateResult`: 채팅방 참여 시 입장 메시지 포함
- `GroupChatRoomLeaveResult`: 채팅방 나가기 시 퇴장 메시지 포함
- `@JsonInclude(NON_NULL)`로 불필요한 null 필드 제거

### 4. 시스템 메시지 자동 생성: 일반 메시지와 전송과 같은 로직 사용 (실시간성을 위함)
- 채팅방 참여 시: "@@님이 입장했습니다" 메시지 자동 생성
- 채팅방 나가기 시: "@@님이 나갔습니다" 메시지 자동 생성

## API 문서
Swagger에서 `joinMessage.code`는 항상 2, `leaveMessage.code`는 항상 3으로 응답됨을 명시